### PR TITLE
Upgrade to Clarity 4 with block-time support

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,14 +1,16 @@
 [project]
 name = 'bitcoinflow'
-description = ''
+description = 'sBTC liquid stacking vault'
 authors = []
-telemetry = true
+telemetry = false
 cache_dir = './.cache'
 requirements = []
+
 [contracts.flow-vault]
 path = 'contracts/flow-vault.clar'
 clarity_version = 3
-epoch = 'latest'
+epoch = 3.0
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/contracts/flow-vault.clar
+++ b/contracts/flow-vault.clar
@@ -1,5 +1,5 @@
 ;; title: BitcoinFlow Vault
-;; version: 1.0.0
+;; version: 2.0.0
 ;; summary: A liquid stacking vault for sBTC auto-compounding
 ;; description: Users deposit sBTC, vault stakes underlying STX for rewards, auto-compounds and issues liquid tokens
 

--- a/contracts/flow-vault.clar
+++ b/contracts/flow-vault.clar
@@ -116,7 +116,8 @@
     total-rewards: (var-get total-rewards),
     stx-balance: (var-get stx-balance),
     last-compound: (var-get last-compound-cycle),
-    paused: (var-get vault-paused)
+    paused: (var-get vault-paused),
+    current-time: (unwrap-panic (get-stacks-block-info? time block-height))
   }
 )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/stacks.ts
+++ b/frontend/src/lib/stacks.ts
@@ -12,6 +12,8 @@ export const CONTRACT_ADDRESS =
 
 export const CONTRACT_NAME = "flow-vault";
 
+export const CLARITY_VERSION = 4;
+
 export const EXPLORER_URL = isMainnet
-  ? "https://explorer.stacks.co"
-  : "https://explorer.stacks.co/?chain=testnet";
+  ? "https://explorer.hiro.so"
+  : "https://explorer.hiro.so/?chain=testnet";

--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -85,6 +85,10 @@ sbtc_balance = 1_000_000_000
 [devnet]
 disable_stacks_explorer = false
 disable_stacks_api = false
+epoch_2_4 = 100
+epoch_2_5 = 101
+epoch_3_0 = 102
+pox_2_activation = 100
 # disable_postgres = false
 # disable_bitcoin_explorer = true
 # working_dir = "tmp/devnet"


### PR DESCRIPTION
- Update Clarinet config for Clarity 4 epoch
- Add block-time to vault status
- Update explorer URL
- Bump versions