### PR TITLE
feat: dark mode and theming improvements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,6 +51,10 @@
     </script>
   </head>
   <body>
+    <script>
+      // Prevent FOUC: apply dark class before first paint
+      (function(){try{if(localStorage.getItem('bf-dark-mode')==='true'||(!localStorage.getItem('bf-dark-mode')&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,7 @@
     <meta name="keywords" content="sBTC, stacking, vault, DeFi, Stacks, Bitcoin, liquid staking, FLOW token" />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
+    <meta name="color-scheme" content="light dark" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -536,6 +536,7 @@
   color: var(--text-muted);
   font-size: 0.85rem;
   margin-bottom: 1rem;
+  transition: color 0.3s;
 }
 
 .action-card button {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -499,6 +499,7 @@
   color: var(--text-primary);
   margin-bottom: 1.5rem;
   text-align: center;
+  transition: color 0.3s;
 }
 
 .action-card input {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -984,16 +984,12 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
   backdrop-filter: blur(2px);
-}
-
-.dark .loading-overlay {
-  background: rgba(0, 0, 0, 0.7);
 }
 
 .action-card button.loading {
@@ -1326,11 +1322,7 @@
 }
 
 .confirm-dialog::backdrop {
-  background: rgba(0,0,0,0.5);
-}
-
-.dark .confirm-dialog::backdrop {
-  background: rgba(0,0,0,0.7);
+  background: var(--overlay-bg);
 }
 
 .confirm-dialog h3 {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -122,8 +122,9 @@
   margin-bottom: 3rem;
   padding: 2rem;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-radius: 20px;
+  border-radius: var(--radius-xl);
   color: white;
+  transition: background 0.3s;
 }
 
 .header-top {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -834,11 +834,12 @@
   font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
   background: var(--bg-secondary);
   padding: 0.75rem;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   margin-bottom: 1rem;
   word-break: break-all;
   max-height: 120px;
   overflow-y: auto;
+  transition: background 0.3s;
 }
 
 @media (max-width: 480px) {
@@ -1141,7 +1142,7 @@
 .tx-clear-btn {
   background: none;
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 0.35rem 0.75rem;
   font-size: 0.8rem;
   cursor: pointer;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -880,10 +880,11 @@
   background: var(--warning-bg);
   color: var(--warning-text);
   padding: 1rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   margin-bottom: 1.5rem;
   text-align: center;
   border: 1px solid #fcd34d;
+  transition: background 0.3s, color 0.3s;
 }
 
 .paused-banner strong {
@@ -900,10 +901,11 @@
   background: #1e293b;
   color: #94a3b8;
   padding: 0.75rem 1.5rem;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   margin-bottom: 1rem;
   text-align: center;
   border: 1px solid #475569;
+  transition: background 0.3s, border-color 0.3s;
 }
 
 .offline-banner strong {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -570,9 +570,10 @@
   background: rgba(255,255,255,0.7);
   margin-bottom: 1rem;
   padding: 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   position: relative;
   padding-left: 3rem;
+  transition: background 0.3s;
 }
 
 .info-section li:before {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1245,6 +1245,10 @@
 .tx-status-confirmed { background: var(--success-bg); color: var(--success-text); }
 .tx-status-failed { background: var(--error-bg); color: var(--error-text); }
 
+.dark .tx-status-pending { border: 1px solid rgba(252, 211, 77, 0.3); }
+.dark .tx-status-confirmed { border: 1px solid rgba(134, 239, 172, 0.3); }
+.dark .tx-status-failed { border: 1px solid rgba(252, 165, 165, 0.3); }
+
 .tx-time {
   color: var(--text-muted);
   font-size: 0.8rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1581,6 +1581,15 @@
   .wallet-address-link::after {
     content: none;
   }
+
+  /* Force light colors in print regardless of theme */
+  .dark .stat-card,
+  .dark .action-card,
+  .dark .tx-history,
+  .dark .vault-stats {
+    background: #fff !important;
+    color: #000 !important;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -839,11 +839,13 @@
 .error-boundary h2 {
   color: var(--error-text);
   margin-bottom: 1rem;
+  transition: color 0.3s;
 }
 
 .error-boundary p {
   color: var(--text-secondary);
   margin-bottom: 1.5rem;
+  transition: color 0.3s;
 }
 
 .error-boundary button {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -454,14 +454,14 @@
 .action-card {
   background: var(--bg-card);
   padding: 2rem;
-  border-radius: 20px;
-  transition: box-shadow 0.2s ease;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+  border-radius: var(--radius-xl);
+  transition: box-shadow 0.2s ease, background 0.3s, border-color 0.3s;
+  box-shadow: var(--shadow-lg);
   border: 1px solid var(--border-color);
 }
 
 .action-card:hover {
-  box-shadow: 0 15px 40px rgba(0,0,0,0.15);
+  box-shadow: var(--shadow-xl);
   border-color: var(--accent);
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -475,10 +475,10 @@
   width: 100%;
   padding: 1rem;
   border: 2px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   font-size: 1rem;
   margin-bottom: 1rem;
-  transition: border-color 0.3s ease;
+  transition: border-color 0.3s ease, background 0.3s, color 0.3s;
   background: var(--bg-primary);
   color: var(--text-primary);
   min-height: 48px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1283,6 +1283,10 @@
   background: rgba(0,0,0,0.5);
 }
 
+.dark .confirm-dialog::backdrop {
+  background: rgba(0,0,0,0.7);
+}
+
 .confirm-dialog h3 {
   margin: 0 0 0.75rem;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -559,6 +559,14 @@
   transform: none;
 }
 
+.dark .action-card button {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.dark .action-card button:hover:not(:disabled) {
+  box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+}
+
 .info-section {
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 2rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -286,7 +286,8 @@
   background: var(--bg-secondary);
   padding: 2rem;
   border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-lg);
+  transition: background 0.3s, box-shadow 0.3s;
 }
 
 .stats-header {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1292,9 +1292,10 @@
   background: none;
   border: 1px solid var(--border-color);
   padding: 0.5rem 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--text-secondary);
+  transition: background 0.2s, border-color 0.2s;
 }
 
 .confirm-dialog-confirm {
@@ -1302,8 +1303,9 @@
   color: white;
   border: none;
   padding: 0.5rem 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
+  transition: background 0.2s;
 }
 
 .confirm-dialog-confirm:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,6 +28,7 @@
   --radius-lg: 15px;
   --radius-xl: 20px;
   --surface-hover: rgba(0,0,0,0.04);
+  --overlay-bg: rgba(0,0,0,0.5);
 }
 
 .dark {
@@ -56,6 +57,7 @@
   --shadow-lg: 0 10px 30px rgba(0,0,0,0.3);
   --shadow-xl: 0 20px 60px rgba(0,0,0,0.4);
   --surface-hover: rgba(255,255,255,0.06);
+  --overlay-bg: rgba(0,0,0,0.7);
 }
 
 *:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -184,6 +184,16 @@
   border: 1px solid rgba(255, 200, 50, 0.4);
 }
 
+.dark .network-badge-mainnet {
+  background: rgba(74, 222, 128, 0.2);
+  border-color: rgba(74, 222, 128, 0.4);
+}
+
+.dark .network-badge-testnet {
+  background: rgba(250, 204, 21, 0.15);
+  border-color: rgba(250, 204, 21, 0.3);
+}
+
 .pending-badge {
   display: inline-block;
   background: rgba(255, 200, 50, 0.3);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1261,12 +1261,12 @@
 
 .confirm-dialog {
   border: none;
-  border-radius: 16px;
+  border-radius: var(--radius-xl);
   padding: 2rem;
   max-width: 400px;
   background: var(--bg-card);
   color: var(--text-primary);
-  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  box-shadow: var(--shadow-xl);
 }
 
 .confirm-dialog::backdrop {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -857,13 +857,14 @@
   background: var(--error-bg);
   color: var(--error-text);
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   margin-bottom: 1rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
   border: 1px solid var(--error-text);
+  transition: background 0.3s, color 0.3s, border-color 0.3s;
 }
 
 .error-banner p {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -29,6 +29,7 @@
   --radius-xl: 20px;
   --surface-hover: rgba(0,0,0,0.04);
   --overlay-bg: rgba(0,0,0,0.5);
+  --focus-ring: rgba(102, 126, 234, 0.25);
 }
 
 .dark {
@@ -58,6 +59,7 @@
   --shadow-xl: 0 20px 60px rgba(0,0,0,0.4);
   --surface-hover: rgba(255,255,255,0.06);
   --overlay-bg: rgba(0,0,0,0.7);
+  --focus-ring: rgba(129, 140, 248, 0.3);
 }
 
 *:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,6 +27,7 @@
   --radius-md: 10px;
   --radius-lg: 15px;
   --radius-xl: 20px;
+  --surface-hover: rgba(0,0,0,0.04);
 }
 
 .dark {
@@ -54,6 +55,7 @@
   --shadow-md: 0 5px 15px rgba(0,0,0,0.25);
   --shadow-lg: 0 10px 30px rgba(0,0,0,0.3);
   --shadow-xl: 0 20px 60px rgba(0,0,0,0.4);
+  --surface-hover: rgba(255,255,255,0.06);
 }
 
 *:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -156,6 +156,11 @@
 
 .theme-toggle:hover {
   background: rgba(255,255,255,0.3);
+  transform: rotate(15deg);
+}
+
+.theme-toggle:active {
+  transform: rotate(30deg) scale(0.9);
 }
 
 .header-badges {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -604,6 +604,7 @@
   text-align: center;
   margin-bottom: 1.5rem;
   color: var(--text-primary);
+  transition: color 0.3s;
 }
 
 .info-section ul {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -316,7 +316,7 @@
 }
 
 .loading-dot {
-  color: #667eea;
+  color: var(--accent);
   font-size: 1.2rem;
   animation: pulse 1s ease-in-out infinite;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1390,6 +1390,10 @@
   background: var(--bg-secondary);
 }
 
+.dark .confirm-dialog-confirm {
+  background: var(--accent);
+}
+
 .confirm-dialog-confirm:active,
 .confirm-dialog-cancel:active {
   transform: scale(0.97);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -503,6 +503,10 @@
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
 }
 
+.dark .action-card input:focus {
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.2);
+}
+
 .action-card small {
   display: block;
   color: var(--text-muted);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1291,6 +1291,7 @@
   color: var(--accent);
   font-size: 0.8rem;
   text-decoration: none;
+  transition: color 0.3s;
 }
 
 .tx-explorer-link:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1267,6 +1267,7 @@
 .tx-amount {
   color: var(--text-primary);
   font-weight: 500;
+  transition: color 0.3s;
 }
 
 .tx-status {
@@ -1287,6 +1288,7 @@
 .tx-time {
   color: var(--text-muted);
   font-size: 0.8rem;
+  transition: color 0.3s;
 }
 
 .tx-explorer-link {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1108,8 +1108,9 @@
 .tx-history {
   background: var(--bg-secondary);
   padding: 2rem;
-  border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  transition: background 0.3s, box-shadow 0.3s;
 }
 
 .tx-history h3 {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -423,8 +423,9 @@
 .user-position {
   background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%);
   padding: 2rem;
-  border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.08);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  transition: background 0.3s, box-shadow 0.3s;
 }
 
 .dark .app-header {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -514,10 +514,10 @@
   color: white;
   border: none;
   padding: 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   font-size: 1.1rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s;
   min-height: 48px;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1048,6 +1048,7 @@
 .footer-links a {
   color: var(--accent);
   text-decoration: none;
+  transition: color 0.3s;
 }
 
 .footer-links a:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -68,7 +68,7 @@
 }
 
 .dark *:focus-visible {
-  outline-color: #a5b4fc;
+  outline-color: var(--accent);
 }
 
 .action-card input:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1181,6 +1181,7 @@
   color: var(--text-muted);
   font-weight: 400;
   font-size: 0.85rem;
+  transition: color 0.3s;
 }
 
 .tx-history-header {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1025,8 +1025,8 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  border-radius: 10px;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
   animation: slideIn 0.3s ease-out;
   font-size: 0.9rem;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1402,6 +1402,7 @@
   font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 0.85rem;
   word-break: break-all;
+  transition: color 0.3s;
 }
 
 .explorer-link:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1037,6 +1037,10 @@
   border-radius: 2px;
 }
 
+.dark .app-footer {
+  border-top-color: var(--border-color);
+}
+
 .toast-container {
   position: fixed;
   top: 1rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -230,7 +230,7 @@
 .wallet-info {
   background: rgba(255,255,255,0.1);
   padding: 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   backdrop-filter: blur(10px);
   display: flex;
   align-items: center;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -262,7 +262,7 @@
   color: white;
   border: 1px solid rgba(255, 100, 100, 0.5);
   padding: 0.5rem 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -324,7 +324,7 @@
 .refresh-btn {
   background: none;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   padding: 0.4rem 0.6rem;
   font-size: 1.2rem;
   cursor: pointer;
@@ -408,7 +408,7 @@
   background: linear-gradient(90deg, #e5e7eb 25%, #f3f4f6 50%, #e5e7eb 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 
 .dark .skeleton {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,6 +38,8 @@
   --text-muted: #94a3b8;
   --border-color: #334155;
   --accent: #818cf8;
+  --accent-hover: #6d7bf4;
+  --accent-active: #5b6bee;
   --accent-secondary: #a78bfa;
   --error-bg: #450a0a;
   --error-text: #fca5a5;
@@ -48,6 +50,10 @@
   --success-text: #86efac;
   --info-bg: #1e3a5f;
   --info-text: #93c5fd;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.2);
+  --shadow-md: 0 5px 15px rgba(0,0,0,0.25);
+  --shadow-lg: 0 10px 30px rgba(0,0,0,0.3);
+  --shadow-xl: 0 20px 60px rgba(0,0,0,0.4);
 }
 
 *:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -980,6 +980,7 @@
   min-height: 36px;
   min-width: 36px;
   padding: 0.25rem 0.5rem;
+  transition: opacity 0.2s, color 0.3s;
 }
 
 .dismiss-btn:focus-visible {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1221,6 +1221,7 @@
   text-align: center;
   padding: 2rem 0;
   font-size: 0.9rem;
+  transition: color 0.3s;
 }
 
 .tx-list {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1165,6 +1165,7 @@
 .tx-history h3 {
   color: var(--text-primary);
   margin: 0;
+  transition: color 0.3s;
 }
 
 .tx-count {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -803,9 +803,9 @@
   color: white;
   border: none;
   padding: 0.75rem 1.5rem;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s, background 0.3s;
 }
 
 .error-boundary button:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1026,9 +1026,9 @@
   animation: spin 0.6s linear infinite;
 }
 
-.field-error { color: var(--error-text); font-size: 0.85rem; margin-top: 4px; min-height: 1.2em; }
-.action-card input.invalid { border-color: var(--error-text); background: var(--error-bg); }
-.action-card input.valid { border-color: var(--success); }
+.field-error { color: var(--error-text); font-size: 0.85rem; margin-top: 4px; min-height: 1.2em; transition: color 0.3s; }
+.action-card input.invalid { border-color: var(--error-text); background: var(--error-bg); transition: border-color 0.3s, background 0.3s; }
+.action-card input.valid { border-color: var(--success); transition: border-color 0.3s; }
 
 .app-footer {
   text-align: center;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1313,7 +1313,7 @@
   font-size: 0.75rem;
   cursor: pointer;
   color: var(--text-muted);
-  transition: all 0.2s;
+  transition: all 0.2s, background 0.3s, border-color 0.3s;
   min-height: 32px;
   min-width: 44px;
   display: inline-flex;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -74,11 +74,7 @@
 .action-card input:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.25);
-}
-
-.dark .action-card input:focus-visible {
-  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.3);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .sr-only {
@@ -524,11 +520,7 @@
 .action-card input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
-}
-
-.dark .action-card input:focus {
-  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.2);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .action-card small {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -507,6 +507,10 @@
   background: var(--bg-secondary);
 }
 
+.dark .action-card input:disabled {
+  opacity: 0.5;
+}
+
 .action-card input:focus {
   outline: none;
   border-color: var(--accent);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1032,6 +1032,7 @@
   color: var(--text-muted);
   font-size: 0.9rem;
   border-top: 1px solid var(--border-color);
+  transition: color 0.3s, border-color 0.3s;
 }
 
 .footer-links {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1217,6 +1217,10 @@
   border-bottom: none;
 }
 
+.dark .tx-item {
+  border-bottom-color: var(--border-color);
+}
+
 .tx-item-left, .tx-item-right {
   display: flex;
   align-items: center;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1291,6 +1291,10 @@
   border-color: var(--accent);
 }
 
+.dark .copy-btn {
+  background: rgba(255,255,255,0.05);
+}
+
 .confirm-dialog {
   border: none;
   border-radius: var(--radius-xl);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -540,8 +540,9 @@
 .info-section {
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 2rem;
-  border-radius: 20px;
+  border-radius: var(--radius-xl);
   margin-top: 2rem;
+  transition: background 0.3s;
 }
 
 .dark .info-section {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -416,6 +416,7 @@
   margin-bottom: 0.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
+  transition: color 0.3s;
 }
 
 .stat-card p {
@@ -424,6 +425,7 @@
   color: var(--text-primary);
   margin: 0;
   word-break: break-word;
+  transition: color 0.3s;
 }
 
 .skeleton {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -233,6 +233,10 @@
   color: #667eea;
 }
 
+.dark .connect-btn:hover {
+  color: #4338ca;
+}
+
 .connect-btn:active {
   transform: scale(0.97);
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1346,11 +1346,14 @@
 
 .confirm-dialog h3 {
   margin: 0 0 0.75rem;
+  color: var(--text-primary);
+  transition: color 0.3s;
 }
 
 .confirm-dialog p {
   color: var(--text-secondary);
   margin: 0 0 1.5rem;
+  transition: color 0.3s;
 }
 
 .confirm-dialog-actions {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -487,6 +487,10 @@
   border-color: var(--accent);
 }
 
+.dark .action-card {
+  border-color: var(--border-color);
+}
+
 .action-card h3 {
   color: var(--text-primary);
   margin-bottom: 1.5rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,6 +7,8 @@
   --text-muted: #6b7280;
   --border-color: #e1e8ed;
   --accent: #667eea;
+  --accent-hover: #5a6fd8;
+  --accent-active: #4f63c6;
   --accent-secondary: #764ba2;
   --error-bg: #fee2e2;
   --error-text: #dc2626;
@@ -17,6 +19,14 @@
   --success-text: #065f46;
   --info-bg: #dbeafe;
   --info-text: #1d4ed8;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
+  --shadow-md: 0 5px 15px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 30px rgba(0,0,0,0.1);
+  --shadow-xl: 0 20px 60px rgba(0,0,0,0.15);
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 15px;
+  --radius-xl: 20px;
 }
 
 .dark {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -395,6 +395,10 @@
   box-shadow: var(--shadow-lg);
 }
 
+.dark .stat-card:hover {
+  background: var(--surface-hover);
+}
+
 .stat-card.loading {
   opacity: 0.7;
   pointer-events: none;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -318,6 +318,7 @@
 .stats-header h2 {
   color: var(--text-primary);
   margin: 0;
+  transition: color 0.3s;
 }
 
 .stats-contract-link {
@@ -325,6 +326,7 @@
   font-size: 0.8rem;
   text-decoration: none;
   margin-left: auto;
+  transition: color 0.3s;
 }
 
 .stats-contract-link:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1519,6 +1519,20 @@
     border-top-color: Highlight;
   }
 
+  .error-boundary {
+    border: 2px solid ButtonText;
+  }
+
+  .confirm-dialog {
+    border: 2px solid ButtonText;
+  }
+
+  .error-banner,
+  .paused-banner,
+  .offline-banner {
+    border: 1px solid ButtonText;
+  }
+
   *:focus-visible {
     outline: 2px solid Highlight;
   }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -783,7 +783,9 @@
   margin: 2rem auto;
   background: var(--error-bg);
   border: 1px solid var(--border-color);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  transition: background 0.3s, border-color 0.3s;
 }
 
 .error-boundary h2 {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -366,16 +366,16 @@
 .stat-card {
   background: var(--bg-card);
   padding: 1.5rem;
-  border-radius: 15px;
-  box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
   text-align: center;
   border: 1px solid var(--border-color);
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.3s, border-color 0.3s;
 }
 
 .stat-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+  box-shadow: var(--shadow-lg);
 }
 
 .stat-card.loading {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useTheme } from './hooks/useTheme'
 import { useWallet } from './hooks/useWallet'
 import { useVaultStats } from './hooks/useVaultStats'
 import { useUserPosition } from './hooks/useUserPosition'
@@ -37,17 +38,7 @@ function App() {
   const { toasts, removeToast, success: toastSuccess, error: toastError, info: toastInfo } = useToast()
   const { checkStatus } = useTransactionStatus()
   const isOnline = useOnlineStatus()
-  const [darkMode, setDarkMode] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('bf-dark-mode') === 'true'
-    }
-    return false
-  })
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', darkMode)
-    localStorage.setItem('bf-dark-mode', String(darkMode))
-  }, [darkMode])
+  const { isDark: darkMode, toggle: toggleTheme } = useTheme()
 
   const pollPendingTransactions = useCallback(async () => {
     const pending = transactions.filter(tx => tx.status === 'pending');
@@ -187,7 +178,7 @@ function App() {
           <h1>BitcoinFlow</h1>
           <button
             className="theme-toggle"
-            onClick={() => setDarkMode(!darkMode)}
+            onClick={toggleTheme}
             aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
           >
             {darkMode ? '☀' : '☾'}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -22,6 +22,7 @@ export { usePrevious } from './usePrevious';
 export { useReducedMotion } from './useReducedMotion';
 export { useScrollLock } from './useScrollLock';
 export { useStableCallback } from './useStableCallback';
+export { useTheme } from './useTheme';
 export { useTimeout } from './useTimeout';
 export { useToast } from './useToast';
 export { useTransactionHistory } from './useTransactionHistory';

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect, useCallback } from 'react';
+import { THEME } from '../lib/constants';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+function getInitialMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  const stored = localStorage.getItem(THEME.STORAGE_KEY);
+  if (stored !== null) return stored === 'true';
+  return window.matchMedia(THEME.SYSTEM_PREFERENCE_QUERY).matches;
+}
+
+export function useTheme() {
+  const [isDark, setIsDark] = useState(getInitialMode);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle(THEME.CLASS_NAME, isDark);
+    localStorage.setItem(THEME.STORAGE_KEY, String(isDark));
+  }, [isDark]);
+
+  const toggle = useCallback(() => setIsDark(prev => !prev), []);
+  const setLight = useCallback(() => setIsDark(false), []);
+  const setDark = useCallback(() => setIsDark(true), []);
+
+  return { isDark, toggle, setLight, setDark } as const;
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { THEME } from '../lib/constants';
 import { getStoredTheme, applyTheme, persistTheme, getColorScheme } from '../lib/theme';
 
 export function useTheme() {
@@ -12,6 +13,18 @@ export function useTheme() {
       meta.setAttribute('content', getColorScheme(isDark));
     }
   }, [isDark]);
+
+  // Sync with system preference when no explicit choice stored
+  useEffect(() => {
+    const mql = window.matchMedia(THEME.SYSTEM_PREFERENCE_QUERY);
+    const handler = (e: MediaQueryListEvent) => {
+      if (localStorage.getItem(THEME.STORAGE_KEY) === null) {
+        setIsDark(e.matches);
+      }
+    };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
 
   const toggle = useCallback(() => setIsDark(prev => !prev), []);
   const setLight = useCallback(() => setIsDark(false), []);

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getStoredTheme, applyTheme, persistTheme } from '../lib/theme';
+import { getStoredTheme, applyTheme, persistTheme, getColorScheme } from '../lib/theme';
 
 export function useTheme() {
   const [isDark, setIsDark] = useState(getStoredTheme);
@@ -7,6 +7,10 @@ export function useTheme() {
   useEffect(() => {
     applyTheme(isDark);
     persistTheme(isDark);
+    const meta = document.querySelector('meta[name="color-scheme"]');
+    if (meta) {
+      meta.setAttribute('content', getColorScheme(isDark));
+    }
   }, [isDark]);
 
   const toggle = useCallback(() => setIsDark(prev => !prev), []);

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,21 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import { THEME } from '../lib/constants';
-
-export type ThemeMode = 'light' | 'dark' | 'system';
-
-function getInitialMode(): boolean {
-  if (typeof window === 'undefined') return false;
-  const stored = localStorage.getItem(THEME.STORAGE_KEY);
-  if (stored !== null) return stored === 'true';
-  return window.matchMedia(THEME.SYSTEM_PREFERENCE_QUERY).matches;
-}
+import { getStoredTheme, applyTheme, persistTheme } from '../lib/theme';
 
 export function useTheme() {
-  const [isDark, setIsDark] = useState(getInitialMode);
+  const [isDark, setIsDark] = useState(getStoredTheme);
 
   useEffect(() => {
-    document.documentElement.classList.toggle(THEME.CLASS_NAME, isDark);
-    localStorage.setItem(THEME.STORAGE_KEY, String(isDark));
+    applyTheme(isDark);
+    persistTheme(isDark);
   }, [isDark]);
 
   const toggle = useCallback(() => setIsDark(prev => !prev), []);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,3 +98,11 @@ img {
   scrollbar-width: thin;
   scrollbar-color: var(--border-color, #d1d5db) transparent;
 }
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #475569;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #64748b;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,10 +39,20 @@ body {
 a {
   color: var(--accent, #667eea);
   text-decoration: none;
+  transition: color 0.3s ease;
 }
 
 a:hover {
   text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.dark img {
+  filter: brightness(0.95);
 }
 
 ::selection {

--- a/frontend/src/lib/__tests__/constants.test.ts
+++ b/frontend/src/lib/__tests__/constants.test.ts
@@ -20,6 +20,7 @@ import {
   SEO,
   BREAKPOINTS,
   KEYS,
+  THEME,
 } from '../constants';
 
 describe('constants', () => {
@@ -142,5 +143,23 @@ describe('KEYS', () => {
     expect(KEYS.ESCAPE).toBe('Escape');
     expect(KEYS.TAB).toBe('Tab');
     expect(KEYS.SPACE).toBe(' ');
+  });
+});
+
+describe('THEME constants', () => {
+  it('has a storage key', () => {
+    expect(THEME.STORAGE_KEY).toBe('bf-dark-mode');
+  });
+
+  it('has a positive transition duration', () => {
+    expect(THEME.TRANSITION_DURATION_MS).toBeGreaterThan(0);
+  });
+
+  it('has a class name', () => {
+    expect(THEME.CLASS_NAME).toBe('dark');
+  });
+
+  it('has a system preference query', () => {
+    expect(THEME.SYSTEM_PREFERENCE_QUERY).toContain('prefers-color-scheme');
   });
 });

--- a/frontend/src/lib/__tests__/theme.test.ts
+++ b/frontend/src/lib/__tests__/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
-import { getColorScheme, applyTheme, persistTheme } from '../theme';
+import { getColorScheme, applyTheme, persistTheme, systemPrefersDark } from '../theme';
 
 describe('getColorScheme', () => {
   it('returns "dark" when isDark is true', () => {
@@ -77,5 +77,37 @@ describe('persistTheme', () => {
   it('stores "false" for light mode', () => {
     persistTheme(false);
     expect(localStorage.getItem('bf-dark-mode')).toBe('false');
+  });
+});
+
+describe('systemPrefersDark', () => {
+  it('returns false when matchMedia reports no dark preference', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    expect(systemPrefersDark()).toBe(false);
+  });
+
+  it('returns true when matchMedia reports dark preference', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    expect(systemPrefersDark()).toBe(true);
   });
 });

--- a/frontend/src/lib/__tests__/theme.test.ts
+++ b/frontend/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { getColorScheme } from '../theme';
+
+describe('getColorScheme', () => {
+  it('returns "dark" when isDark is true', () => {
+    expect(getColorScheme(true)).toBe('dark');
+  });
+
+  it('returns "light" when isDark is false', () => {
+    expect(getColorScheme(false)).toBe('light');
+  });
+});
+
+describe('getStoredTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns false when nothing is stored and system prefers light', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    const { getStoredTheme } = await import('../theme');
+    expect(getStoredTheme()).toBe(false);
+  });
+
+  it('returns true when stored value is "true"', async () => {
+    localStorage.setItem('bf-dark-mode', 'true');
+    const { getStoredTheme } = await import('../theme');
+    expect(getStoredTheme()).toBe(true);
+  });
+
+  it('returns false when stored value is "false"', async () => {
+    localStorage.setItem('bf-dark-mode', 'false');
+    const { getStoredTheme } = await import('../theme');
+    expect(getStoredTheme()).toBe(false);
+  });
+});

--- a/frontend/src/lib/__tests__/theme.test.ts
+++ b/frontend/src/lib/__tests__/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
-import { getColorScheme } from '../theme';
+import { getColorScheme, applyTheme, persistTheme } from '../theme';
 
 describe('getColorScheme', () => {
   it('returns "dark" when isDark is true', () => {
@@ -44,5 +44,38 @@ describe('getStoredTheme', () => {
     localStorage.setItem('bf-dark-mode', 'false');
     const { getStoredTheme } = await import('../theme');
     expect(getStoredTheme()).toBe(false);
+  });
+});
+
+describe('applyTheme', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('adds dark class when isDark is true', () => {
+    applyTheme(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('removes dark class when isDark is false', () => {
+    document.documentElement.classList.add('dark');
+    applyTheme(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});
+
+describe('persistTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores "true" for dark mode', () => {
+    persistTheme(true);
+    expect(localStorage.getItem('bf-dark-mode')).toBe('true');
+  });
+
+  it('stores "false" for light mode', () => {
+    persistTheme(false);
+    expect(localStorage.getItem('bf-dark-mode')).toBe('false');
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -56,6 +56,13 @@ export const ANIMATION = {
   COPY_FEEDBACK_MS: 2000,
 } as const;
 
+export const THEME = {
+  STORAGE_KEY: 'bf-dark-mode',
+  TRANSITION_DURATION_MS: 300,
+  CLASS_NAME: 'dark',
+  SYSTEM_PREFERENCE_QUERY: '(prefers-color-scheme: dark)',
+} as const;
+
 export const PERFORMANCE = {
   RESIZE_DEBOUNCE_MS: 150,
   SCROLL_THROTTLE_MS: 100,

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,30 @@
+import { THEME } from './constants';
+
+/** Check if system prefers dark color scheme */
+export function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia(THEME.SYSTEM_PREFERENCE_QUERY).matches;
+}
+
+/** Read stored theme preference, falling back to system preference */
+export function getStoredTheme(): boolean {
+  if (typeof window === 'undefined') return false;
+  const stored = localStorage.getItem(THEME.STORAGE_KEY);
+  if (stored === null) return systemPrefersDark();
+  return stored === 'true';
+}
+
+/** Apply the dark class to the document root */
+export function applyTheme(isDark: boolean): void {
+  document.documentElement.classList.toggle(THEME.CLASS_NAME, isDark);
+}
+
+/** Persist theme to localStorage */
+export function persistTheme(isDark: boolean): void {
+  localStorage.setItem(THEME.STORAGE_KEY, String(isDark));
+}
+
+/** Generate a CSS color-scheme meta tag value */
+export function getColorScheme(isDark: boolean): string {
+  return isDark ? 'dark' : 'light';
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,6 +88,8 @@ export interface StackingInfo {
 
 export type LoadingState = 'idle' | 'loading' | 'success' | 'error';
 
+export type ThemeMode = 'light' | 'dark' | 'system';
+
 export interface FormField<T = string> {
   value: T;
   error: string | null;


### PR DESCRIPTION
## Summary

- Add CSS custom property design tokens for shadows, radii, surface-hover, overlay-bg, and focus-ring
- Create useTheme hook with localStorage persistence, system preference sync, and FOUC prevention
- Create theme utility module (applyTheme, persistTheme, getStoredTheme, systemPrefersDark, getColorScheme)
- Replace all hardcoded shadow, border-radius, and overlay values with CSS tokens
- Add smooth theme transition animations on all major UI elements
- Add dark mode variants for network badges, status badges, copy button, action-card buttons, scrollbar, and banners
- Add color-scheme meta tag and inline FOUC prevention script
- Add forced-colors accessibility support for error-boundary, confirm-dialog, and banners
- Add dark mode print override to force light colors
- Add comprehensive theme utility tests

## Test plan

- [x] Verify dark mode toggles correctly and persists across refreshes
- [x] Verify FOUC prevention works (no flash of wrong theme on load)
- [x] Verify system preference detection works when no explicit preference stored
- [x] Verify all CSS tokens resolve correctly in both light and dark modes
- [x] Verify smooth transitions when switching themes
- [x] Verify forced-colors mode renders properly
- [x] Verify print mode forces light theme
- [x] Run theme utility unit tests