### PR TITLE
Add real-time STX price feed

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { KeyboardShortcutHelp } from './components/KeyboardShortcutHelp'
 import { preconnectHiroApi } from './lib/resourceHints'
 import { reportWebVitals } from './lib/webVitals'
+import { PriceDisplay } from './components/PriceDisplay'
 import './App.css'
 
 // Preconnect to Hiro API on module load for faster first request
@@ -205,6 +206,7 @@ function App() {
       <header className="app-header" role="banner" aria-label={LANDMARK_LABELS.header}>
         <div className="header-top">
           <h1>BitcoinFlow</h1>
+          <PriceDisplay />
           <button
             className="theme-toggle"
             onClick={toggleTheme}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,8 @@ import { KeyboardShortcutHelp } from './components/KeyboardShortcutHelp'
 import { preconnectHiroApi } from './lib/resourceHints'
 import { reportWebVitals } from './lib/webVitals'
 import { PriceDisplay } from './components/PriceDisplay'
+import { usePriceFeed } from './hooks/usePriceFeed'
+import { calculatePortfolioValue, formatUSD, microSTXtoSTX } from './lib/priceUtils'
 import './App.css'
 
 // Preconnect to Hiro API on module load for faster first request
@@ -55,6 +57,7 @@ function App() {
   const { checkStatus } = useTransactionStatus()
   const isOnline = useOnlineStatus()
   const { isDark: darkMode, toggle: toggleTheme } = useTheme()
+  const { price: stxPrice } = usePriceFeed()
   const [showShortcuts, setShowShortcuts] = useState(false)
   const [depositTouched, setDepositTouched] = useState(false)
   const [withdrawTouched, setWithdrawTouched] = useState(false)
@@ -290,6 +293,11 @@ function App() {
               <div className={`stat-card${statsLoading ? ' loading' : ''}`} aria-label={`STX Balance: ${formattedBalance} STX`}>
                 <h3>STX Balance</h3>
                 <p>{formattedBalance} STX</p>
+                {stxPrice && (
+                  <p className="stat-usd-equiv" aria-label="USD equivalent">
+                    ≈ {formatUSD(calculatePortfolioValue(microSTXtoSTX(vaultStats.stxBalance), stxPrice.usd))}
+                  </p>
+                )}
               </div>
               <div className={`stat-card${statsLoading ? ' loading' : ''}`} aria-label={`Your Flow Tokens: ${formattedUserTokens} FLOW`}>
                 <h3>Your Flow Tokens</h3>

--- a/frontend/src/components/PriceBadge.tsx
+++ b/frontend/src/components/PriceBadge.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { PriceData } from '../types/price';
+import { formatUSD, isPositiveChange } from '../lib/priceUtils';
+
+interface PriceBadgeProps {
+  price: PriceData | null;
+}
+
+export function PriceBadge({ price }: PriceBadgeProps) {
+  if (!price) {
+    return (
+      <span className="price-badge price-badge-loading" aria-label="STX price loading" aria-busy="true">
+        <span className="price-skeleton" style={{ width: 64, height: 14, display: 'inline-block' }} aria-hidden="true" />
+      </span>
+    );
+  }
+
+  const positive = isPositiveChange(price.change24h);
+  const colorClass = positive ? 'price-badge-up' : 'price-badge-down';
+  const arrow = positive ? '▲' : '▼';
+
+  return (
+    <span
+      className={`price-badge ${colorClass}`}
+      aria-label={`STX price ${formatUSD(price.usd)}, ${positive ? 'up' : 'down'} ${Math.abs(price.change24h).toFixed(2)}% in 24 hours`}
+      title={`STX/USD — 24h: ${price.change24h > 0 ? '+' : ''}${price.change24h.toFixed(2)}%`}
+    >
+      <span aria-hidden="true" className="price-badge-arrow">{arrow}</span>
+      <span className="price-badge-value">{formatUSD(price.usd)}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/PriceBadge.tsx
+++ b/frontend/src/components/PriceBadge.tsx
@@ -4,9 +4,11 @@ import { formatUSD, isPositiveChange } from '../lib/priceUtils';
 
 interface PriceBadgeProps {
   price: PriceData | null;
+  /** When true, shows the STX/BTC rate instead of STX/USD */
+  showBtcRate?: boolean;
 }
 
-export function PriceBadge({ price }: PriceBadgeProps) {
+export function PriceBadge({ price, showBtcRate = false }: PriceBadgeProps) {
   if (!price) {
     return (
       <span className="price-badge price-badge-loading" aria-label="STX price loading" aria-busy="true">
@@ -18,6 +20,21 @@ export function PriceBadge({ price }: PriceBadgeProps) {
   const positive = isPositiveChange(price.change24h);
   const colorClass = positive ? 'price-badge-up' : 'price-badge-down';
   const arrow = positive ? '▲' : '▼';
+
+  if (showBtcRate && price.btc > 0) {
+    const btcFormatted = price.btc < 0.001
+      ? price.btc.toExponential(4)
+      : price.btc.toFixed(8);
+    return (
+      <span
+        className="price-badge"
+        aria-label={`STX/BTC rate: ${btcFormatted}`}
+        title="STX price in BTC"
+      >
+        <span className="price-badge-value">₿ {btcFormatted}</span>
+      </span>
+    );
+  }
 
   return (
     <span

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+
+interface PriceChartProps {
+  history: number[];
+  width?: number;
+  height?: number;
+  strokeColor?: string;
+  fillId?: string;
+}
+
+export function PriceChart({
+  history,
+  width = 240,
+  height = 60,
+  strokeColor = '#16a34a',
+  fillId,
+}: PriceChartProps) {
+  const gradientId = fillId || 'price-chart-gradient';
+
+  const { polylinePoints, polygonPoints } = useMemo(() => {
+    if (history.length < 2) return { polylinePoints: '', polygonPoints: '' };
+
+    const min = Math.min(...history);
+    const max = Math.max(...history);
+    const range = max - min || 1;
+    const padding = 4;
+    const chartH = height - padding * 2;
+    const chartW = width;
+
+    const coords = history.map((price, i) => {
+      const x = (i / (history.length - 1)) * chartW;
+      const y = padding + chartH - ((price - min) / range) * chartH;
+      return { x, y };
+    });
+
+    const linePoints = coords.map(({ x, y }) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ');
+
+    // Closed polygon for gradient fill: line + baseline
+    const first = coords[0];
+    const last = coords[coords.length - 1];
+    const fillPoints = [
+      ...coords.map(({ x, y }) => `${x.toFixed(2)},${y.toFixed(2)}`),
+      `${last.x.toFixed(2)},${height}`,
+      `${first.x.toFixed(2)},${height}`,
+    ].join(' ');
+
+    return { polylinePoints: linePoints, polygonPoints: fillPoints };
+  }, [history, width, height]);
+
+  if (history.length < 2) {
+    return (
+      <div className="price-chart price-chart-empty" aria-hidden="true" style={{ width, height }}>
+        <span style={{ fontSize: 11, color: '#9ca3af' }}>Not enough data</span>
+      </div>
+    );
+  }
+
+  const isPositive = history[history.length - 1] >= history[0];
+  const color = isPositive ? '#16a34a' : '#dc2626';
+  const fillColor = isPositive ? '#dcfce7' : '#fee2e2';
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="price-chart"
+      aria-hidden="true"
+      role="img"
+      aria-label="STX price history sparkline"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={fillColor} stopOpacity="0.8" />
+          <stop offset="100%" stopColor={fillColor} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* Gradient fill area */}
+      <polygon
+        points={polygonPoints}
+        fill={`url(#${gradientId})`}
+        stroke="none"
+      />
+
+      {/* Price line */}
+      <polyline
+        points={polylinePoints}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* End dot */}
+      {history.length > 0 && (() => {
+        const last = polylinePoints.split(' ').pop();
+        if (!last) return null;
+        const [x, y] = last.split(',').map(Number);
+        return <circle cx={x} cy={y} r={2.5} fill={color} />;
+      })()}
+    </svg>
+  );
+}

--- a/frontend/src/components/PriceDisplay.tsx
+++ b/frontend/src/components/PriceDisplay.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { usePriceFeed } from '../hooks/usePriceFeed';
+import { formatUSD, formatChangePercent, isPositiveChange } from '../lib/priceUtils';
+
+export function PriceDisplay() {
+  const { price, loading, error, refresh, history } = usePriceFeed();
+
+  if (loading && !price) {
+    return (
+      <div className="price-display" aria-label="Loading STX price" aria-busy="true">
+        <div className="price-skeleton" style={{ width: 120, height: 28 }} />
+        <div className="price-skeleton" style={{ width: 80, height: 18, marginTop: 6 }} />
+      </div>
+    );
+  }
+
+  if (error && !price) {
+    return (
+      <div className="price-display price-error-banner" role="alert">
+        <span>Price unavailable: {error}</span>
+        <button className="price-retry-btn" onClick={refresh} aria-label="Retry fetching STX price">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!price) return null;
+
+  const positive = isPositiveChange(price.change24h);
+  const arrow = positive ? '▲' : '▼';
+  const changeClass = positive ? 'price-up' : 'price-down';
+  const updatedDate = new Date(price.updatedAt);
+  const timeStr = updatedDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  return (
+    <div className="price-display" aria-label={`STX price: ${formatUSD(price.usd)}`}>
+      <div className="price-main">
+        <span className="price-value">{formatUSD(price.usd)}</span>
+        <span className={`price-change ${changeClass}`} aria-label={`24h change: ${formatChangePercent(price.change24h)}`}>
+          <span aria-hidden="true">{arrow}</span>
+          {formatChangePercent(price.change24h)}
+        </span>
+      </div>
+      <div className="price-meta">
+        <span className="price-label">STX/USD</span>
+        <span className="price-updated" aria-label={`Last updated at ${timeStr}`}>
+          Updated {timeStr}
+        </span>
+        <button
+          className="price-refresh-btn"
+          onClick={refresh}
+          disabled={loading}
+          aria-label="Refresh STX price"
+          aria-busy={loading}
+        >
+          {loading ? '…' : '↻'}
+        </button>
+      </div>
+      {history.length > 1 && (
+        <PriceSparklineInline prices={history.map(h => h.usd)} />
+      )}
+    </div>
+  );
+}
+
+function PriceSparklineInline({ prices }: { prices: number[] }) {
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const range = max - min || 1;
+  const w = 120;
+  const h = 32;
+  const points = prices
+    .map((p, i) => {
+      const x = (i / (prices.length - 1)) * w;
+      const y = h - ((p - min) / range) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+
+  return (
+    <svg
+      width={w}
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
+      aria-hidden="true"
+      className="price-sparkline"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/PriceDisplay.tsx
+++ b/frontend/src/components/PriceDisplay.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { usePriceFeed } from '../hooks/usePriceFeed';
+import { PriceChart } from './PriceChart';
 import { formatUSD, formatChangePercent, isPositiveChange } from '../lib/priceUtils';
 
 export function PriceDisplay() {
@@ -82,42 +83,13 @@ export function PriceDisplay() {
         </button>
       </div>
       {history.length > 1 && (
-        <PriceSparklineInline prices={history.map(h => h.usd)} />
+        <PriceChart
+          history={history.map(h => h.usd)}
+          width={200}
+          height={48}
+        />
       )}
     </div>
   );
 }
 
-function PriceSparklineInline({ prices }: { prices: number[] }) {
-  const min = Math.min(...prices);
-  const max = Math.max(...prices);
-  const range = max - min || 1;
-  const w = 120;
-  const h = 32;
-  const points = prices
-    .map((p, i) => {
-      const x = (i / (prices.length - 1)) * w;
-      const y = h - ((p - min) / range) * h;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(' ');
-
-  return (
-    <svg
-      width={w}
-      height={h}
-      viewBox={`0 0 ${w} ${h}`}
-      aria-hidden="true"
-      className="price-sparkline"
-    >
-      <polyline
-        points={points}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}

--- a/frontend/src/components/PriceDisplay.tsx
+++ b/frontend/src/components/PriceDisplay.tsx
@@ -7,9 +7,13 @@ export function PriceDisplay() {
 
   if (loading && !price) {
     return (
-      <div className="price-display" aria-label="Loading STX price" aria-busy="true">
-        <div className="price-skeleton" style={{ width: 120, height: 28 }} />
-        <div className="price-skeleton" style={{ width: 80, height: 18, marginTop: 6 }} />
+      <div className="price-display" aria-label="Loading STX price" aria-busy="true" role="status">
+        <div className="price-skeleton-wrapper">
+          <div className="price-skeleton" style={{ width: 128, height: 28, marginBottom: 6 }} aria-hidden="true" />
+          <div className="price-skeleton" style={{ width: 72, height: 16, marginBottom: 4 }} aria-hidden="true" />
+          <div className="price-skeleton" style={{ width: 96, height: 12 }} aria-hidden="true" />
+        </div>
+        <span className="sr-only">Fetching current STX price…</span>
       </div>
     );
   }

--- a/frontend/src/components/PriceDisplay.tsx
+++ b/frontend/src/components/PriceDisplay.tsx
@@ -20,14 +20,26 @@ export function PriceDisplay() {
 
   if (error && !price) {
     return (
-      <div className="price-display price-error-banner" role="alert">
-        <span>Price unavailable: {error}</span>
-        <button className="price-retry-btn" onClick={refresh} aria-label="Retry fetching STX price">
-          Retry
+      <div className="price-display price-error-banner" role="alert" aria-live="assertive">
+        <div className="price-error-content">
+          <span className="price-error-icon" aria-hidden="true">⚠</span>
+          <span className="price-error-text">Price unavailable — {error}</span>
+        </div>
+        <button
+          className="price-retry-btn"
+          onClick={refresh}
+          aria-label="Retry fetching STX price"
+          disabled={loading}
+          aria-busy={loading}
+        >
+          {loading ? 'Retrying…' : 'Retry'}
         </button>
       </div>
     );
   }
+
+  // Stale price warning banner (price loaded but fetch failed)
+  const showStaleWarning = error && price !== null;
 
   if (!price) return null;
 
@@ -39,6 +51,14 @@ export function PriceDisplay() {
 
   return (
     <div className="price-display" aria-label={`STX price: ${formatUSD(price.usd)}`}>
+      {showStaleWarning && (
+        <div className="price-stale-banner" role="status" aria-live="polite">
+          <span>Showing cached price — </span>
+          <button className="price-retry-btn price-retry-inline" onClick={refresh} aria-label="Retry fetching STX price">
+            Refresh
+          </button>
+        </div>
+      )}
       <div className="price-main">
         <span className="price-value">{formatUSD(price.usd)}</span>
         <span className={`price-change ${changeClass}`} aria-label={`24h change: ${formatChangePercent(price.change24h)}`}>

--- a/frontend/src/config/priceConfig.ts
+++ b/frontend/src/config/priceConfig.ts
@@ -1,0 +1,26 @@
+import type { PriceFeedConfig } from '../types/price';
+
+/** How often to poll for a new STX price (30 seconds). */
+export const PRICE_REFRESH_INTERVAL_MS = 30_000;
+
+/** How long a cached price reading is considered fresh (5 minutes). */
+export const PRICE_CACHE_TTL_MS = 300_000;
+
+/** Hiro API endpoint for current STX/USD price. */
+export const HIRO_PRICE_API = 'https://api.hiro.so/extended/v1/market/stx/price';
+
+/** Maximum number of data points kept in the price history ring buffer. */
+export const PRICE_HISTORY_MAX_POINTS = 20;
+
+/** Request timeout for price fetches. */
+export const PRICE_REQUEST_TIMEOUT_MS = 8_000;
+
+/** Number of retries on network failure before giving up. */
+export const PRICE_MAX_RETRIES = 3;
+
+/** Default PriceFeedConfig used by PriceService. */
+export const DEFAULT_PRICE_FEED_CONFIG: PriceFeedConfig = {
+  refreshIntervalMs: PRICE_REFRESH_INTERVAL_MS,
+  cacheTtlMs: PRICE_CACHE_TTL_MS,
+  apiBase: HIRO_PRICE_API,
+};

--- a/frontend/src/hooks/usePriceFeed.ts
+++ b/frontend/src/hooks/usePriceFeed.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { PriceService } from '../services/priceService';
+import type { PriceData } from '../types/price';
+
+const POLL_INTERVAL_MS = 30_000;
+const HISTORY_MAX_POINTS = 20;
+
+export interface UsePriceFeedReturn {
+  price: PriceData | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+  history: PriceData[];
+  btcRate: number | null;
+}
+
+export function usePriceFeed(): UsePriceFeedReturn {
+  const [price, setPrice] = useState<PriceData | null>(() => PriceService.instance.getCached());
+  const [loading, setLoading] = useState<boolean>(price === null);
+  const [error, setError] = useState<string | null>(null);
+  const [history, setHistory] = useState<PriceData[]>([]);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const addToHistory = useCallback((data: PriceData) => {
+    setHistory(prev => {
+      const next = [...prev, data];
+      return next.length > HISTORY_MAX_POINTS ? next.slice(next.length - HISTORY_MAX_POINTS) : next;
+    });
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await PriceService.instance.fetchCurrentPrice();
+      setPrice(data);
+      addToHistory(data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to fetch STX price';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [addToHistory]);
+
+  // Poll every 30 seconds
+  useEffect(() => {
+    refresh();
+    intervalRef.current = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [refresh]);
+
+  // Refresh on window focus
+  useEffect(() => {
+    const handleFocus = () => refresh();
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, [refresh]);
+
+  const btcRate = price?.btc ?? null;
+
+  return { price, loading, error, refresh, history, btcRate };
+}

--- a/frontend/src/hooks/usePriceFeed.ts
+++ b/frontend/src/hooks/usePriceFeed.ts
@@ -60,11 +60,18 @@ export function usePriceFeed(): UsePriceFeedReturn {
     };
   }, [refresh]);
 
-  // Refresh on window focus
+  // Refresh on window focus and document visibility change
   useEffect(() => {
     const handleFocus = () => refresh();
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
     window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
   }, [refresh]);
 
   const btcRate = price?.btc ?? null;

--- a/frontend/src/hooks/usePriceFeed.ts
+++ b/frontend/src/hooks/usePriceFeed.ts
@@ -12,6 +12,7 @@ export interface UsePriceFeedReturn {
   refresh: () => void;
   history: PriceData[];
   btcRate: number | null;
+  lastFetchedAt: number | null;
 }
 
 export function usePriceFeed(): UsePriceFeedReturn {
@@ -19,7 +20,9 @@ export function usePriceFeed(): UsePriceFeedReturn {
   const [loading, setLoading] = useState<boolean>(price === null);
   const [error, setError] = useState<string | null>(null);
   const [history, setHistory] = useState<PriceData[]>([]);
+  const [lastFetchedAt, setLastFetchedAt] = useState<number | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const refreshingRef = useRef(false);
 
   const addToHistory = useCallback((data: PriceData) => {
     setHistory(prev => {
@@ -29,17 +32,22 @@ export function usePriceFeed(): UsePriceFeedReturn {
   }, []);
 
   const refresh = useCallback(async () => {
+    // Prevent concurrent fetches
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
     setLoading(true);
     setError(null);
     try {
       const data = await PriceService.instance.fetchCurrentPrice();
       setPrice(data);
+      setLastFetchedAt(Date.now());
       addToHistory(data);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to fetch STX price';
       setError(msg);
     } finally {
       setLoading(false);
+      refreshingRef.current = false;
     }
   }, [addToHistory]);
 
@@ -61,5 +69,5 @@ export function usePriceFeed(): UsePriceFeedReturn {
 
   const btcRate = price?.btc ?? null;
 
-  return { price, loading, error, refresh, history, btcRate };
+  return { price, loading, error, refresh, history, btcRate, lastFetchedAt };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -106,3 +106,170 @@ img {
 .dark ::-webkit-scrollbar-thumb:hover {
   background: #64748b;
 }
+
+/* ── Price feed styles ────────────────────────────────────────── */
+
+.price-up {
+  color: #16a34a;
+}
+
+.price-down {
+  color: #dc2626;
+}
+
+.price-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: #f0fdf4;
+}
+
+.price-badge-up {
+  color: #16a34a;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+}
+
+.price-badge-down {
+  color: #dc2626;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+}
+
+.price-skeleton {
+  display: block;
+  animation: price-pulse 1.5s ease-in-out infinite;
+  background: #e5e7eb;
+  border-radius: 4px;
+}
+
+.price-skeleton-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+@keyframes price-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.price-display {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.875rem;
+}
+
+.price-main {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.price-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.price-change {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.price-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+.price-label {
+  font-weight: 600;
+}
+
+.price-updated {
+  opacity: 0.75;
+}
+
+.price-refresh-btn,
+.price-retry-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: #6b7280;
+  transition: color 0.15s, background 0.15s;
+}
+
+.price-refresh-btn:hover,
+.price-retry-btn:hover {
+  color: #111827;
+  background: #f3f4f6;
+}
+
+.price-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #dc2626;
+}
+
+.price-error-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+}
+
+.price-stale-banner {
+  font-size: 0.75rem;
+  color: #b45309;
+  background: #fffbeb;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.price-sparkline {
+  opacity: 0.8;
+  color: #16a34a;
+}
+
+.price-chart {
+  display: block;
+}
+
+.price-chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/frontend/src/lib/priceUtils.ts
+++ b/frontend/src/lib/priceUtils.ts
@@ -1,0 +1,56 @@
+const usdFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/**
+ * Format a USD amount with $ prefix and 2 decimal places.
+ */
+export function formatUSD(usd: number): string {
+  return usdFormatter.format(usd);
+}
+
+/**
+ * Format a 24h price change percentage with + or - sign.
+ */
+export function formatChangePercent(change: number): string {
+  const sign = change >= 0 ? '+' : '';
+  return `${sign}${change.toFixed(2)}%`;
+}
+
+/**
+ * Convert micro-STX units to STX (divide by 1,000,000).
+ */
+export function microSTXtoSTX(micro: number): number {
+  return micro / 1_000_000;
+}
+
+/**
+ * Calculate total portfolio value in USD given an STX amount and current price.
+ */
+export function calculatePortfolioValue(stxAmount: number, priceUSD: number): number {
+  return stxAmount * priceUSD;
+}
+
+/**
+ * Format an STX amount to 6 decimal places.
+ */
+export function formatSTXAmount(stx: number): string {
+  return stx.toFixed(6);
+}
+
+/**
+ * Return true if the 24h change is positive or zero.
+ */
+export function isPositiveChange(change: number): boolean {
+  return change >= 0;
+}
+
+/**
+ * Return a Tailwind text color class based on whether the price change is positive.
+ */
+export function getPriceChangeColor(change: number): string {
+  return change >= 0 ? 'text-green-600' : 'text-red-600';
+}

--- a/frontend/src/lib/priceUtils.ts
+++ b/frontend/src/lib/priceUtils.ts
@@ -54,3 +54,35 @@ export function isPositiveChange(change: number): boolean {
 export function getPriceChangeColor(change: number): string {
   return change >= 0 ? 'text-green-600' : 'text-red-600';
 }
+
+/**
+ * Format a large USD value compactly (e.g. $1.2M, $34.5K).
+ */
+export function formatUSDCompact(usd: number): string {
+  if (Math.abs(usd) >= 1_000_000) {
+    return `$${(usd / 1_000_000).toFixed(2)}M`;
+  }
+  if (Math.abs(usd) >= 1_000) {
+    return `$${(usd / 1_000).toFixed(2)}K`;
+  }
+  return usdFormatter.format(usd);
+}
+
+/**
+ * Clamp a value between min and max.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Normalize an array of price values to a 0–1 range for chart rendering.
+ */
+export function normalizePrices(prices: number[]): number[] {
+  if (prices.length === 0) return [];
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const range = max - min;
+  if (range === 0) return prices.map(() => 0.5);
+  return prices.map(p => (p - min) / range);
+}

--- a/frontend/src/services/priceService.ts
+++ b/frontend/src/services/priceService.ts
@@ -1,12 +1,18 @@
-import type { PriceData } from '../types/price';
+import type { PriceData, PriceFetchError } from '../types/price';
 
 const CACHE_KEY = 'stx_price_cache';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const PRICE_API_URL = 'https://api.hiro.so/extended/v1/market/stx/price';
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 2_000;
 
 interface PriceCache {
   data: PriceData;
   fetchedAt: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export class PriceService {
@@ -19,28 +25,57 @@ export class PriceService {
     return PriceService._instance;
   }
 
+  private async fetchWithRetry(retries = MAX_RETRIES): Promise<PriceData> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 8_000);
+
+        const response = await fetch(PRICE_API_URL, {
+          method: 'GET',
+          headers: { 'Accept': 'application/json' },
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (response.status === 429) {
+          const retryAfter = parseInt(response.headers.get('Retry-After') || '60', 10);
+          const error: PriceFetchError = {
+            code: 'RATE_LIMITED',
+            message: 'Rate limited by price API',
+            retryAfter: retryAfter * 1000,
+          };
+          throw new Error(error.message);
+        }
+
+        if (!response.ok) {
+          throw new Error(`Price API error: ${response.status} ${response.statusText}`);
+        }
+
+        const json = await response.json();
+
+        const priceData: PriceData = {
+          usd: parseFloat(json.price || json.usd || '0'),
+          btc: parseFloat(json.btc_price || json.btc || '0'),
+          change24h: parseFloat(json.change_24h || json.percent_change_24h || '0'),
+          updatedAt: Date.now(),
+        };
+
+        this.saveCache(priceData);
+        return priceData;
+      } catch (err) {
+        const isLastAttempt = attempt === retries;
+        if (isLastAttempt) throw err;
+        await sleep(RETRY_DELAY_MS * Math.pow(2, attempt));
+      }
+    }
+    throw new Error('Exhausted retries fetching STX price');
+  }
+
   async fetchCurrentPrice(): Promise<PriceData> {
     try {
-      const response = await fetch(PRICE_API_URL, {
-        method: 'GET',
-        headers: { 'Accept': 'application/json' },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Price API error: ${response.status} ${response.statusText}`);
-      }
-
-      const json = await response.json();
-
-      const priceData: PriceData = {
-        usd: parseFloat(json.price || json.usd || '0'),
-        btc: parseFloat(json.btc_price || json.btc || '0'),
-        change24h: parseFloat(json.change_24h || json.percent_change_24h || '0'),
-        updatedAt: Date.now(),
-      };
-
-      this.saveCache(priceData);
-      return priceData;
+      return await this.fetchWithRetry();
     } catch (err) {
       const cached = this.getCached();
       if (cached) return cached;
@@ -76,7 +111,7 @@ export class PriceService {
     }
   }
 
-  subscribe(callback: (data: PriceData) => void): () => void {
+  subscribe(callback: (data: PriceData) => void, onError?: (err: Error) => void): () => void {
     let active = true;
 
     const poll = async () => {
@@ -85,7 +120,9 @@ export class PriceService {
         const data = await this.fetchCurrentPrice();
         if (active) callback(data);
       } catch (err) {
-        console.error('[PriceService] subscribe poll error:', err);
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error('[PriceService] subscribe poll error:', error.message);
+        if (active && onError) onError(error);
       }
     };
 

--- a/frontend/src/services/priceService.ts
+++ b/frontend/src/services/priceService.ts
@@ -1,0 +1,100 @@
+import type { PriceData } from '../types/price';
+
+const CACHE_KEY = 'stx_price_cache';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const PRICE_API_URL = 'https://api.hiro.so/extended/v1/market/stx/price';
+
+interface PriceCache {
+  data: PriceData;
+  fetchedAt: number;
+}
+
+export class PriceService {
+  private static _instance: PriceService | null = null;
+
+  static get instance(): PriceService {
+    if (!PriceService._instance) {
+      PriceService._instance = new PriceService();
+    }
+    return PriceService._instance;
+  }
+
+  async fetchCurrentPrice(): Promise<PriceData> {
+    try {
+      const response = await fetch(PRICE_API_URL, {
+        method: 'GET',
+        headers: { 'Accept': 'application/json' },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Price API error: ${response.status} ${response.statusText}`);
+      }
+
+      const json = await response.json();
+
+      const priceData: PriceData = {
+        usd: parseFloat(json.price || json.usd || '0'),
+        btc: parseFloat(json.btc_price || json.btc || '0'),
+        change24h: parseFloat(json.change_24h || json.percent_change_24h || '0'),
+        updatedAt: Date.now(),
+      };
+
+      this.saveCache(priceData);
+      return priceData;
+    } catch (err) {
+      const cached = this.getCached();
+      if (cached) return cached;
+      throw err;
+    }
+  }
+
+  getCached(): PriceData | null {
+    try {
+      const raw = localStorage.getItem(CACHE_KEY);
+      if (!raw) return null;
+
+      const cache: PriceCache = JSON.parse(raw);
+      const age = Date.now() - cache.fetchedAt;
+
+      if (age > CACHE_TTL_MS) {
+        localStorage.removeItem(CACHE_KEY);
+        return null;
+      }
+
+      return cache.data;
+    } catch {
+      return null;
+    }
+  }
+
+  saveCache(data: PriceData): void {
+    try {
+      const cache: PriceCache = { data, fetchedAt: Date.now() };
+      localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+    } catch {
+      // localStorage may be unavailable in some environments
+    }
+  }
+
+  subscribe(callback: (data: PriceData) => void): () => void {
+    let active = true;
+
+    const poll = async () => {
+      if (!active) return;
+      try {
+        const data = await this.fetchCurrentPrice();
+        if (active) callback(data);
+      } catch (err) {
+        console.error('[PriceService] subscribe poll error:', err);
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 30_000);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }
+}

--- a/frontend/src/types/price.ts
+++ b/frontend/src/types/price.ts
@@ -1,0 +1,23 @@
+export interface PriceData {
+  usd: number;
+  btc: number;
+  change24h: number;
+  updatedAt: number;
+}
+
+export interface PriceHistory {
+  timestamps: number[];
+  prices: number[];
+}
+
+export interface PriceFeedConfig {
+  refreshIntervalMs: number;
+  cacheTtlMs: number;
+  apiBase: string;
+}
+
+export interface PriceFetchError {
+  code: string;
+  message: string;
+  retryAfter?: number;
+}

--- a/frontend/src/types/price.ts
+++ b/frontend/src/types/price.ts
@@ -21,3 +21,21 @@ export interface PriceFetchError {
   message: string;
   retryAfter?: number;
 }
+
+/** Possible error codes returned by the price API or service layer. */
+export type PriceFetchErrorCode =
+  | 'NETWORK_ERROR'
+  | 'RATE_LIMITED'
+  | 'PARSE_ERROR'
+  | 'TIMEOUT'
+  | 'UNKNOWN';
+
+/** Snapshot of multiple asset prices at a single moment in time. */
+export interface PriceSnapshot {
+  stxUsd: number;
+  stxBtc: number;
+  capturedAt: number;
+}
+
+// Re-export all price types as a convenience barrel
+export type { PriceData as STXPriceData };


### PR DESCRIPTION
## Summary
- Add PriceService with singleton pattern, TTL cache, exponential backoff retry, and subscribe method
- Add usePriceFeed hook with 30s polling, focus/visibility refresh, and price history ring buffer
- Add PriceDisplay component with skeleton loading, stale/error banners, and sparkline chart
- Add PriceBadge, PriceChart (SVG gradient sparkline), and priceUtils formatting helpers
- Integrate live STX/USD price and USD equivalent in app header and vault balance