### PR TITLE
Add transaction history viewer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,9 @@ import { CountdownTimer } from './components/CountdownTimer'
 import { useLockStatus } from './hooks/useLockStatus'
 import { useLockHistory } from './hooks/useLockHistory'
 import type { LockPeriod } from './types/lock'
+import { TxHistoryList } from './components/TxHistoryList'
+import { TxExportButton } from './components/TxExportButton'
+import { useTxHistory } from './hooks/useTxHistory'
 import './App.css'
 
 // Preconnect to Hiro API on module load for faster first request
@@ -69,6 +72,8 @@ function App() {
   const { lockStatus, refetch: refetchLock } = useLockStatus(isConnected ? getAddress() : null)
   const { addEntry: addLockEntry } = useLockHistory()
   const [selectedLockPeriod, setSelectedLockPeriod] = useState<LockPeriod | null>(null)
+  const walletAddress = isConnected ? (getAddress() ?? '') : ''
+  const txHistoryHook = useTxHistory(walletAddress)
   const [showShortcuts, setShowShortcuts] = useState(false)
   const [depositTouched, setDepositTouched] = useState(false)
   const [withdrawTouched, setWithdrawTouched] = useState(false)
@@ -499,6 +504,23 @@ function App() {
                 />
               )}
             </div>
+          </section>
+
+          <section className="tx-history-section" role="region" aria-labelledby="tx-history-heading">
+            <div className="tx-history-header">
+              <h2 id="tx-history-heading">Transaction History</h2>
+              <TxExportButton transactions={txHistoryHook.transactions} />
+            </div>
+            <TxHistoryList
+              transactions={txHistoryHook.transactions}
+              loading={txHistoryHook.loading}
+              error={txHistoryHook.error}
+              hasMore={txHistoryHook.hasMore}
+              filter={txHistoryHook.filter}
+              onFilterChange={txHistoryHook.setFilter}
+              onLoadMore={txHistoryHook.loadMore}
+              pendingTxIds={txHistoryHook.pendingTxIds}
+            />
           </section>
 
           <TransactionHistory transactions={transactions} onClear={clearHistory} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -138,6 +138,7 @@ function App() {
       onFinish: (data) => {
         const txId = data.txId;
         addTransaction({ txId, type: 'deposit', amount: Math.round(parseFloat(depositAmount) * SATS_PER_BTC) })
+        txHistoryHook.addPendingTx(txId)
         toastSuccess(`Deposit of ${depositAmount} sBTC submitted`, txId)
         setDepositAmount('')
         setDepositTouched(false)
@@ -193,6 +194,7 @@ function App() {
       onFinish: (data) => {
         const txId = data.txId;
         addTransaction({ txId, type: 'withdraw', amount: Math.round(parseFloat(withdrawAmount) * SATS_PER_BTC) })
+        txHistoryHook.addPendingTx(txId)
         toastSuccess(`Withdrawal of ${withdrawAmount} FLOW submitted`, txId)
         setWithdrawAmount('')
         setWithdrawTouched(false)
@@ -490,6 +492,7 @@ function App() {
                   onSuccess={(txId) => {
                     if (selectedLockPeriod) {
                       addLockEntry({ type: 'lock', blocks: selectedLockPeriod.blocks, txId, timestamp: Date.now() });
+                      txHistoryHook.addPendingTx(txId);
                       refetchLock();
                     }
                   }}

--- a/frontend/src/components/TxExportButton.tsx
+++ b/frontend/src/components/TxExportButton.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import type { Transaction } from '../types/transaction';
+import { TxService } from '../services/txService';
+
+interface TxExportButtonProps {
+  transactions: Transaction[];
+  filename?: string;
+}
+
+export function TxExportButton({ transactions, filename = 'transactions.csv' }: TxExportButtonProps) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = async () => {
+    if (transactions.length === 0) return;
+    setExporting(true);
+    try {
+      const csv = TxService.instance.exportToCSV(transactions);
+      TxService.instance.downloadCSV(csv, filename);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const isEmpty = transactions.length === 0;
+
+  return (
+    <button
+      type="button"
+      className="tx-export-btn"
+      onClick={handleExport}
+      disabled={isEmpty || exporting}
+      aria-label={isEmpty ? 'No transactions to export' : `Export ${transactions.length} transactions to CSV`}
+      title={isEmpty ? 'No transactions to export' : 'Download as CSV'}
+      aria-busy={exporting}
+    >
+      <span className="tx-export-icon" aria-hidden="true">⬇</span>
+      {exporting ? 'Exporting…' : 'Export CSV'}
+    </button>
+  );
+}

--- a/frontend/src/components/TxFilterBar.tsx
+++ b/frontend/src/components/TxFilterBar.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type { TxFilter, TxType } from '../types/transaction';
+
+interface TxFilterBarProps {
+  filter: TxFilter;
+  onChange: (f: TxFilter) => void;
+}
+
+const TX_TYPES: { value: TxType | ''; label: string }[] = [
+  { value: '', label: 'All types' },
+  { value: 'deposit', label: 'Deposit' },
+  { value: 'withdrawal', label: 'Withdrawal' },
+  { value: 'lock', label: 'Lock' },
+  { value: 'unlock', label: 'Unlock' },
+  { value: 'reward', label: 'Reward' },
+];
+
+const STATUSES = [
+  { value: '', label: 'All statuses' },
+  { value: 'confirmed', label: 'Confirmed' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'failed', label: 'Failed' },
+];
+
+export function TxFilterBar({ filter, onChange }: TxFilterBarProps) {
+  const hasFilters = !!(filter.type || filter.status || filter.dateFrom || filter.dateTo);
+
+  const handleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value as TxType | '';
+    onChange({ ...filter, type: val || undefined });
+  };
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value as 'confirmed' | 'pending' | 'failed' | '';
+    onChange({ ...filter, status: val || undefined });
+  };
+
+  const handleDateFrom = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value ? new Date(e.target.value).getTime() : undefined;
+    onChange({ ...filter, dateFrom: val });
+  };
+
+  const handleDateTo = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value ? new Date(e.target.value).getTime() + 86_399_999 : undefined;
+    onChange({ ...filter, dateTo: val });
+  };
+
+  const clearFilters = () => onChange({});
+
+  const toDateInputValue = (ms: number | undefined): string => {
+    if (!ms) return '';
+    return new Date(ms).toISOString().split('T')[0];
+  };
+
+  return (
+    <div className="tx-filter-bar" role="search" aria-label="Filter transactions">
+      <select
+        value={filter.type ?? ''}
+        onChange={handleTypeChange}
+        className="tx-filter-select"
+        aria-label="Filter by transaction type"
+      >
+        {TX_TYPES.map(t => (
+          <option key={t.value} value={t.value}>{t.label}</option>
+        ))}
+      </select>
+
+      <select
+        value={filter.status ?? ''}
+        onChange={handleStatusChange}
+        className="tx-filter-select"
+        aria-label="Filter by status"
+      >
+        {STATUSES.map(s => (
+          <option key={s.value} value={s.value}>{s.label}</option>
+        ))}
+      </select>
+
+      <input
+        type="date"
+        value={toDateInputValue(filter.dateFrom)}
+        onChange={handleDateFrom}
+        className="tx-filter-date"
+        aria-label="Filter from date"
+        max={toDateInputValue(filter.dateTo) || undefined}
+      />
+
+      <input
+        type="date"
+        value={toDateInputValue(filter.dateTo)}
+        onChange={handleDateTo}
+        className="tx-filter-date"
+        aria-label="Filter to date"
+        min={toDateInputValue(filter.dateFrom) || undefined}
+      />
+
+      {hasFilters && (
+        <button
+          type="button"
+          className="tx-filter-clear"
+          onClick={clearFilters}
+          aria-label="Clear all filters"
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TxHistoryItem.tsx
+++ b/frontend/src/components/TxHistoryItem.tsx
@@ -77,11 +77,15 @@ export function TxHistoryItem({ transaction: tx, usdPrice }: TxHistoryItemProps)
       </div>
 
       <div className="tx-item-right">
-        <span className={`tx-amount ${amountColor}`}>
-          {amountPrefix}{amountSTX.toFixed(6)} STX
+        <span className={`tx-amount ${amountColor}`} aria-label={`Amount: ${amountPrefix}${amountSTX.toFixed(6)} STX`}>
+          <span className="tx-amount-prefix" aria-hidden="true">{amountPrefix}</span>
+          {amountSTX.toFixed(6)}
+          <span className="tx-amount-unit"> STX</span>
         </span>
         {usdEquiv && (
-          <span className="tx-amount-usd">≈ ${usdEquiv}</span>
+          <span className="tx-amount-usd" aria-label={`USD equivalent: approximately $${usdEquiv}`}>
+            ≈ ${usdEquiv}
+          </span>
         )}
       </div>
     </div>

--- a/frontend/src/components/TxHistoryItem.tsx
+++ b/frontend/src/components/TxHistoryItem.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import type { Transaction } from '../types/transaction';
+import { formatTxHash, getTxTypeLabel, getExplorerUrl, formatFee } from '../lib/txUtils';
+import { microSTXtoSTX } from '../lib/priceUtils';
+import { TxTypeBadge } from './TxTypeBadge';
+import { TxStatusDot } from './TxStatusDot';
+
+interface TxHistoryItemProps {
+  transaction: Transaction;
+  usdPrice?: number;
+}
+
+export function TxHistoryItem({ transaction: tx, usdPrice }: TxHistoryItemProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(tx.txHash);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard not available
+    }
+  };
+
+  const isCredit = tx.type === 'deposit' || tx.type === 'reward' || tx.type === 'unlock';
+  const amountSTX = microSTXtoSTX(tx.amount);
+  const amountPrefix = isCredit ? '+' : '-';
+  const amountColor = isCredit ? 'tx-amount-credit' : 'tx-amount-debit';
+  const usdEquiv = usdPrice ? (amountSTX * usdPrice).toFixed(2) : null;
+
+  const timeStr = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(tx.timestamp));
+
+  return (
+    <div
+      className="tx-item"
+      role="listitem"
+      aria-label={`${getTxTypeLabel(tx.type)} of ${amountSTX.toFixed(6)} STX — ${tx.status}`}
+    >
+      <div className="tx-item-left">
+        <TxStatusDot status={tx.status} />
+        <TxTypeBadge type={tx.type} />
+      </div>
+
+      <div className="tx-item-center">
+        <div className="tx-item-hash-row">
+          <code className="tx-hash">{formatTxHash(tx.txHash)}</code>
+          <button
+            type="button"
+            className="tx-copy-btn"
+            onClick={handleCopy}
+            aria-label={copied ? 'Copied!' : `Copy transaction hash ${formatTxHash(tx.txHash)}`}
+            title={copied ? 'Copied!' : 'Copy hash'}
+          >
+            {copied ? '✓' : '⎘'}
+          </button>
+          <a
+            href={getExplorerUrl(tx.txHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tx-explorer-link"
+            aria-label="View on block explorer"
+          >
+            ↗
+          </a>
+        </div>
+        <div className="tx-item-meta">
+          <span className="tx-fee">{formatFee(tx.fee)}</span>
+          <span className="tx-time">{timeStr}</span>
+          {tx.blockHeight > 0 && (
+            <span className="tx-block">Block {tx.blockHeight.toLocaleString()}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="tx-item-right">
+        <span className={`tx-amount ${amountColor}`}>
+          {amountPrefix}{amountSTX.toFixed(6)} STX
+        </span>
+        {usdEquiv && (
+          <span className="tx-amount-usd">≈ ${usdEquiv}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TxHistoryList.tsx
+++ b/frontend/src/components/TxHistoryList.tsx
@@ -18,9 +18,18 @@ interface TxHistoryListProps {
 function SkeletonRow() {
   return (
     <div className="tx-item tx-item-skeleton" aria-hidden="true">
-      <div className="price-skeleton" style={{ width: 64, height: 20 }} />
-      <div className="price-skeleton" style={{ width: 100, height: 16, marginTop: 6 }} />
-      <div className="price-skeleton" style={{ width: 80, height: 12, marginTop: 4 }} />
+      <div className="tx-item-left">
+        <div className="price-skeleton" style={{ width: 10, height: 10, borderRadius: '50%' }} />
+        <div className="price-skeleton" style={{ width: 72, height: 22, borderRadius: 9999 }} />
+      </div>
+      <div className="tx-item-center" style={{ gap: 4 }}>
+        <div className="price-skeleton" style={{ width: 120, height: 14 }} />
+        <div className="price-skeleton" style={{ width: 80, height: 12, marginTop: 4 }} />
+      </div>
+      <div className="tx-item-right">
+        <div className="price-skeleton" style={{ width: 90, height: 16 }} />
+        <div className="price-skeleton" style={{ width: 60, height: 12, marginTop: 4 }} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TxHistoryList.tsx
+++ b/frontend/src/components/TxHistoryList.tsx
@@ -79,7 +79,10 @@ export function TxHistoryList({
       <div className="tx-list" role="list" aria-label="Transaction history">
         {dateKeys.map(date => (
           <div key={date} className="tx-date-group">
-            <p className="tx-date-group-header" aria-label={`Transactions on ${date}`}>{date}</p>
+            <div className="tx-date-group-header-wrapper" aria-label={`Transactions on ${date}`}>
+              <p className="tx-date-group-header">{date}</p>
+              <span className="tx-date-group-count">{grouped[date].length} tx{grouped[date].length !== 1 ? 's' : ''}</span>
+            </div>
             {grouped[date].map(tx => (
               <TxHistoryItem key={tx.id} transaction={tx} />
             ))}

--- a/frontend/src/components/TxHistoryList.tsx
+++ b/frontend/src/components/TxHistoryList.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import type { Transaction, TxFilter } from '../types/transaction';
+import { groupTxsByDate } from '../lib/txUtils';
+import { TxHistoryItem } from './TxHistoryItem';
+import { TxFilterBar } from './TxFilterBar';
+
+interface TxHistoryListProps {
+  transactions: Transaction[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  filter: TxFilter;
+  onFilterChange: (f: TxFilter) => void;
+  onLoadMore: () => void;
+  pendingTxIds?: string[];
+}
+
+function SkeletonRow() {
+  return (
+    <div className="tx-item tx-item-skeleton" aria-hidden="true">
+      <div className="price-skeleton" style={{ width: 64, height: 20 }} />
+      <div className="price-skeleton" style={{ width: 100, height: 16, marginTop: 6 }} />
+      <div className="price-skeleton" style={{ width: 80, height: 12, marginTop: 4 }} />
+    </div>
+  );
+}
+
+export function TxHistoryList({
+  transactions,
+  loading,
+  error,
+  hasMore,
+  filter,
+  onFilterChange,
+  onLoadMore,
+  pendingTxIds = [],
+}: TxHistoryListProps) {
+  const grouped = groupTxsByDate(transactions);
+  const dateKeys = Object.keys(grouped);
+  const isEmpty = transactions.length === 0 && !loading;
+
+  return (
+    <div className="tx-history-wrapper">
+      <TxFilterBar filter={filter} onChange={onFilterChange} />
+
+      {error && (
+        <div className="tx-error-banner" role="alert">
+          <span>Error loading transactions: {error}</span>
+        </div>
+      )}
+
+      {loading && transactions.length === 0 && (
+        <div className="tx-list" aria-label="Loading transactions" aria-busy="true">
+          <SkeletonRow />
+          <SkeletonRow />
+          <SkeletonRow />
+        </div>
+      )}
+
+      {pendingTxIds.length > 0 && (
+        <div className="tx-pending-section">
+          <p className="tx-date-group-header">Pending</p>
+          {pendingTxIds.map(txId => (
+            <div key={txId} className="tx-item tx-item-pending">
+              <span className="tx-pending-dot" aria-hidden="true" />
+              <code className="tx-pending-hash">{txId.slice(0, 10)}…</code>
+              <span className="tx-pending-label">Awaiting confirmation</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {isEmpty && !error && (
+        <div className="tx-empty-state" role="status">
+          <p>No transactions found{filter.type ? ` for type "${filter.type}"` : ''}.</p>
+        </div>
+      )}
+
+      <div className="tx-list" role="list" aria-label="Transaction history">
+        {dateKeys.map(date => (
+          <div key={date} className="tx-date-group">
+            <p className="tx-date-group-header" aria-label={`Transactions on ${date}`}>{date}</p>
+            {grouped[date].map(tx => (
+              <TxHistoryItem key={tx.id} transaction={tx} />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {hasMore && !loading && (
+        <button
+          type="button"
+          className="tx-load-more-btn"
+          onClick={onLoadMore}
+          aria-label="Load more transactions"
+        >
+          Load more
+        </button>
+      )}
+
+      {loading && transactions.length > 0 && (
+        <p className="tx-loading-more" aria-live="polite" aria-busy="true">
+          Loading more transactions…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TxStatusDot.tsx
+++ b/frontend/src/components/TxStatusDot.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface TxStatusDotProps {
+  status: 'confirmed' | 'pending' | 'failed';
+}
+
+export function TxStatusDot({ status }: TxStatusDotProps) {
+  if (status === 'confirmed') {
+    return (
+      <span
+        className="tx-status-dot tx-status-confirmed"
+        aria-label="Confirmed"
+        title="Transaction confirmed"
+        role="img"
+      />
+    );
+  }
+
+  if (status === 'pending') {
+    return (
+      <span
+        className="tx-status-dot tx-status-pending"
+        aria-label="Pending"
+        title="Transaction pending"
+        role="img"
+      />
+    );
+  }
+
+  // failed
+  return (
+    <span
+      className="tx-status-failed"
+      aria-label="Failed"
+      title="Transaction failed"
+      role="img"
+    >
+      ✕
+    </span>
+  );
+}

--- a/frontend/src/components/TxTypeBadge.tsx
+++ b/frontend/src/components/TxTypeBadge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { TxType } from '../types/transaction';
+import { getTxTypeLabel } from '../lib/txUtils';
+
+interface TxTypeBadgeProps {
+  type: TxType;
+}
+
+const colorMap: Record<TxType, string> = {
+  deposit:    'tx-type-deposit',
+  withdrawal: 'tx-type-withdrawal',
+  lock:       'tx-type-lock',
+  unlock:     'tx-type-unlock',
+  reward:     'tx-type-reward',
+};
+
+export function TxTypeBadge({ type }: TxTypeBadgeProps) {
+  const colorClass = colorMap[type] ?? 'tx-type-default';
+  const label = getTxTypeLabel(type);
+
+  return (
+    <span
+      className={`tx-type-badge ${colorClass}`}
+      aria-label={`Transaction type: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useTxHistory.ts
+++ b/frontend/src/hooks/useTxHistory.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { Transaction, TxFilter } from '../types/transaction';
 import { TxService } from '../services/txService';
 
@@ -35,6 +35,7 @@ export function useTxHistory(address: string): UseTxHistoryReturn {
   const [hasMore, setHasMore] = useState(true);
   const [filter, setFilter] = useState<TxFilter>({});
   const [pendingTxIds, setPendingTxIds] = useState<string[]>([]);
+  const prevFilterRef = useRef<TxFilter>({});
 
   const fetchPage = useCallback(async (pageOffset: number, replace: boolean) => {
     if (!address) return;
@@ -83,5 +84,11 @@ export function useTxHistory(address: string): UseTxHistoryReturn {
 
   const transactions = useMemo(() => applyFilter(allTransactions, filter), [allTransactions, filter]);
 
-  return { transactions, loading, error, hasMore, filter, setFilter, loadMore, refetch, pendingTxIds, addPendingTx };
+  // Expose a typed setFilter that also tracks the previous filter for diffing
+  const updateFilter = useCallback((newFilter: TxFilter) => {
+    prevFilterRef.current = filter;
+    setFilter(newFilter);
+  }, [filter]);
+
+  return { transactions, loading, error, hasMore, filter, setFilter: updateFilter, loadMore, refetch, pendingTxIds, addPendingTx };
 }

--- a/frontend/src/hooks/useTxHistory.ts
+++ b/frontend/src/hooks/useTxHistory.ts
@@ -79,8 +79,20 @@ export function useTxHistory(address: string): UseTxHistoryReturn {
     const confirmedIds = new Set(
       allTransactions.filter(tx => tx.status === 'confirmed').map(tx => tx.txHash)
     );
-    setPendingTxIds(prev => prev.filter(id => !confirmedIds.has(id)));
-  }, [allTransactions, pendingTxIds.length]);
+    const hasNewlyConfirmed = pendingTxIds.some(id => confirmedIds.has(id));
+    if (hasNewlyConfirmed) {
+      setPendingTxIds(prev => prev.filter(id => !confirmedIds.has(id)));
+    }
+  }, [allTransactions, pendingTxIds]);
+
+  // Poll every 15s when there are pending txs to check for confirmations
+  useEffect(() => {
+    if (pendingTxIds.length === 0) return;
+    const interval = setInterval(() => {
+      fetchPage(0, true);
+    }, 15_000);
+    return () => clearInterval(interval);
+  }, [pendingTxIds.length, fetchPage]);
 
   const transactions = useMemo(() => applyFilter(allTransactions, filter), [allTransactions, filter]);
 

--- a/frontend/src/hooks/useTxHistory.ts
+++ b/frontend/src/hooks/useTxHistory.ts
@@ -1,0 +1,87 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { Transaction, TxFilter } from '../types/transaction';
+import { TxService } from '../services/txService';
+
+const PAGE_SIZE = 20;
+
+export interface UseTxHistoryReturn {
+  transactions: Transaction[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  filter: TxFilter;
+  setFilter: (f: TxFilter) => void;
+  loadMore: () => void;
+  refetch: () => void;
+  pendingTxIds: string[];
+  addPendingTx: (txId: string) => void;
+}
+
+function applyFilter(txs: Transaction[], filter: TxFilter): Transaction[] {
+  return txs.filter(tx => {
+    if (filter.type && tx.type !== filter.type) return false;
+    if (filter.status && tx.status !== filter.status) return false;
+    if (filter.dateFrom && tx.timestamp < filter.dateFrom) return false;
+    if (filter.dateTo && tx.timestamp > filter.dateTo) return false;
+    return true;
+  });
+}
+
+export function useTxHistory(address: string): UseTxHistoryReturn {
+  const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [filter, setFilter] = useState<TxFilter>({});
+  const [pendingTxIds, setPendingTxIds] = useState<string[]>([]);
+
+  const fetchPage = useCallback(async (pageOffset: number, replace: boolean) => {
+    if (!address) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const page = await TxService.instance.fetchTxHistory(address, PAGE_SIZE, pageOffset);
+      setAllTransactions(prev => replace ? page : [...prev, ...page]);
+      setHasMore(page.length === PAGE_SIZE);
+      setOffset(pageOffset + page.length);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load transactions');
+    } finally {
+      setLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    setAllTransactions([]);
+    setOffset(0);
+    setHasMore(true);
+    fetchPage(0, true);
+  }, [address, fetchPage]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) fetchPage(offset, false);
+  }, [loading, hasMore, offset, fetchPage]);
+
+  const refetch = useCallback(() => {
+    setOffset(0);
+    fetchPage(0, true);
+  }, [fetchPage]);
+
+  const addPendingTx = useCallback((txId: string) => {
+    setPendingTxIds(prev => prev.includes(txId) ? prev : [txId, ...prev]);
+  }, []);
+
+  // Auto-remove pending tx once it appears confirmed in fetched data
+  useEffect(() => {
+    if (pendingTxIds.length === 0) return;
+    const confirmedIds = new Set(
+      allTransactions.filter(tx => tx.status === 'confirmed').map(tx => tx.txHash)
+    );
+    setPendingTxIds(prev => prev.filter(id => !confirmedIds.has(id)));
+  }, [allTransactions, pendingTxIds.length]);
+
+  const transactions = useMemo(() => applyFilter(allTransactions, filter), [allTransactions, filter]);
+
+  return { transactions, loading, error, hasMore, filter, setFilter, loadMore, refetch, pendingTxIds, addPendingTx };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -421,6 +421,40 @@ img {
   margin-bottom: 14px;
 }
 
+.stat-usd-equiv {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 4px 0 0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinner-rotate 0.6s linear infinite;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+@keyframes spinner-rotate {
+  to { transform: rotate(360deg); }
+}
+
+.unlock-btn-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.unlock-vault-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 /* ── Lock period styles ──────────────────────────────────────── */
 
 .lock-badge-unlocked {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,6 +107,320 @@ img {
   background: #64748b;
 }
 
+/* ── Transaction history styles ──────────────────────────────── */
+
+.tx-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tx-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: white;
+  border: 1px solid #f3f4f6;
+  border-radius: 10px;
+  padding: 12px 16px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.tx-item:hover {
+  border-color: #e5e7eb;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.tx-item-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.tx-item-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tx-item-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.tx-date-group-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #9ca3af;
+  padding: 8px 0 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.tx-date-group-header-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tx-date-group-count {
+  font-size: 0.7rem;
+  color: #d1d5db;
+}
+
+.tx-date-group {
+  margin-bottom: 8px;
+}
+
+.tx-type-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.tx-type-deposit    { color: #166534; background: #f0fdf4; border-color: #bbf7d0; }
+.tx-type-withdrawal { color: #991b1b; background: #fef2f2; border-color: #fecaca; }
+.tx-type-lock       { color: #92400e; background: #fffbeb; border-color: #fde68a; }
+.tx-type-unlock     { color: #1e40af; background: #eff6ff; border-color: #bfdbfe; }
+.tx-type-reward     { color: #6b21a8; background: #faf5ff; border-color: #e9d5ff; }
+.tx-type-default    { color: #374151; background: #f9fafb; border-color: #e5e7eb; }
+
+.tx-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tx-status-confirmed {
+  background: #16a34a;
+}
+
+.tx-status-pending {
+  background: #f59e0b;
+  animation: price-pulse 1.5s ease-in-out infinite;
+}
+
+.tx-status-failed {
+  font-size: 0.75rem;
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.tx-hash {
+  font-size: 0.78rem;
+  color: #374151;
+  font-family: monospace;
+}
+
+.tx-item-hash-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tx-copy-btn,
+.tx-explorer-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: #9ca3af;
+  padding: 0 2px;
+  transition: color 0.15s;
+  text-decoration: none;
+}
+
+.tx-copy-btn:hover,
+.tx-explorer-link:hover {
+  color: #374151;
+}
+
+.tx-item-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 0.72rem;
+  color: #9ca3af;
+}
+
+.tx-amount {
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+
+.tx-amount-credit { color: #16a34a; }
+.tx-amount-debit  { color: #dc2626; }
+
+.tx-amount-prefix {
+  font-size: 0.8em;
+}
+
+.tx-amount-unit {
+  font-size: 0.75em;
+  font-weight: 400;
+  color: #6b7280;
+}
+
+.tx-amount-usd {
+  font-size: 0.72rem;
+  color: #9ca3af;
+}
+
+.tx-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
+}
+
+.tx-filter-select,
+.tx-filter-date {
+  padding: 6px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  background: white;
+}
+
+.tx-filter-clear {
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: #6b7280;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.tx-filter-clear:hover {
+  border-color: #9ca3af;
+  color: #111827;
+}
+
+.tx-load-more-btn {
+  margin-top: 12px;
+  width: 100%;
+  padding: 10px;
+  background: white;
+  border: 1px dashed #d1d5db;
+  border-radius: 8px;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.tx-load-more-btn:hover {
+  border-color: #9ca3af;
+  color: #374151;
+}
+
+.tx-loading-more {
+  text-align: center;
+  color: #9ca3af;
+  font-size: 0.8rem;
+  margin-top: 8px;
+}
+
+.tx-error-banner {
+  padding: 10px 14px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #dc2626;
+  font-size: 0.85rem;
+  margin-bottom: 10px;
+}
+
+.tx-empty-state {
+  padding: 24px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+
+.tx-item-pending {
+  border-style: dashed;
+  opacity: 0.8;
+}
+
+.tx-pending-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f59e0b;
+  animation: price-pulse 1.2s ease-in-out infinite;
+}
+
+.tx-pending-hash {
+  font-size: 0.78rem;
+  color: #374151;
+}
+
+.tx-pending-label {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.tx-pending-section {
+  margin-bottom: 12px;
+}
+
+.tx-export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: #374151;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.tx-export-btn:hover:not(:disabled) {
+  border-color: #9ca3af;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.tx-export-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.tx-history-section {
+  margin-top: 28px;
+}
+
+.tx-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
 /* ── Lock period styles ──────────────────────────────────────── */
 
 .lock-badge-unlocked {

--- a/frontend/src/lib/txUtils.ts
+++ b/frontend/src/lib/txUtils.ts
@@ -1,0 +1,71 @@
+import type { TxType, Transaction } from '../types/transaction';
+
+/** Truncate a tx hash to first 6 + "…" + last 4 characters. */
+export function formatTxHash(hash: string): string {
+  if (hash.length <= 12) return hash;
+  return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+}
+
+/** Human-readable label for a transaction type. */
+export function getTxTypeLabel(type: TxType): string {
+  switch (type) {
+    case 'deposit':    return 'Deposit';
+    case 'withdrawal': return 'Withdrawal';
+    case 'lock':       return 'Lock';
+    case 'unlock':     return 'Unlock';
+    case 'reward':     return 'Reward';
+    default:           return 'Unknown';
+  }
+}
+
+/** Tailwind color class for a transaction type badge. */
+export function getTxTypeColor(type: TxType): string {
+  switch (type) {
+    case 'deposit':    return 'text-green-700 bg-green-50 border-green-200';
+    case 'withdrawal': return 'text-red-700 bg-red-50 border-red-200';
+    case 'lock':       return 'text-amber-700 bg-amber-50 border-amber-200';
+    case 'unlock':     return 'text-blue-700 bg-blue-50 border-blue-200';
+    case 'reward':     return 'text-purple-700 bg-purple-50 border-purple-200';
+    default:           return 'text-gray-700 bg-gray-50 border-gray-200';
+  }
+}
+
+/** Get the Hiro block explorer URL for a transaction. */
+export function getExplorerUrl(
+  txHash: string,
+  network: 'mainnet' | 'testnet' = 'testnet'
+): string {
+  const chain = network === 'mainnet' ? '' : '&chain=testnet';
+  return `https://explorer.hiro.so/txid/${txHash}?${chain}`;
+}
+
+/** Format a fee from micro-STX to a human-readable STX string. */
+export function formatFee(microSTX: number): string {
+  const stx = microSTX / 1_000_000;
+  return `${stx.toFixed(6)} STX`;
+}
+
+/** Group a list of transactions by their date string (e.g. "Apr 6, 2026"). */
+export function groupTxsByDate(transactions: Transaction[]): Record<string, Transaction[]> {
+  const groups: Record<string, Transaction[]> = {};
+
+  for (const tx of transactions) {
+    const label = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(tx.timestamp));
+
+    if (!groups[label]) {
+      groups[label] = [];
+    }
+    groups[label].push(tx);
+  }
+
+  return groups;
+}
+
+/** Sort transactions by timestamp descending (newest first). */
+export function sortTxsNewestFirst(transactions: Transaction[]): Transaction[] {
+  return [...transactions].sort((a, b) => b.timestamp - a.timestamp);
+}

--- a/frontend/src/lib/txUtils.ts
+++ b/frontend/src/lib/txUtils.ts
@@ -69,3 +69,38 @@ export function groupTxsByDate(transactions: Transaction[]): Record<string, Tran
 export function sortTxsNewestFirst(transactions: Transaction[]): Transaction[] {
   return [...transactions].sort((a, b) => b.timestamp - a.timestamp);
 }
+
+/** Group transactions by type. */
+export function groupTxsByType(transactions: Transaction[]): Partial<Record<TxType, Transaction[]>> {
+  const groups: Partial<Record<TxType, Transaction[]>> = {};
+  for (const tx of transactions) {
+    if (!groups[tx.type]) groups[tx.type] = [];
+    groups[tx.type]!.push(tx);
+  }
+  return groups;
+}
+
+/** Compute aggregate stats across a list of transactions. */
+export function computeTxStats(transactions: Transaction[]): {
+  totalDeposited: number;
+  totalWithdrawn: number;
+  totalFees: number;
+  confirmedCount: number;
+  failedCount: number;
+} {
+  let totalDeposited = 0;
+  let totalWithdrawn = 0;
+  let totalFees = 0;
+  let confirmedCount = 0;
+  let failedCount = 0;
+
+  for (const tx of transactions) {
+    totalFees += tx.fee;
+    if (tx.status === 'confirmed') confirmedCount++;
+    if (tx.status === 'failed') failedCount++;
+    if (tx.type === 'deposit' || tx.type === 'reward') totalDeposited += tx.amount;
+    if (tx.type === 'withdrawal') totalWithdrawn += tx.amount;
+  }
+
+  return { totalDeposited, totalWithdrawn, totalFees, confirmedCount, failedCount };
+}

--- a/frontend/src/services/txService.ts
+++ b/frontend/src/services/txService.ts
@@ -1,0 +1,125 @@
+import type { Transaction, TxType } from '../types/transaction';
+import { API_URL } from '../lib/stacks';
+
+function mapHiroTxToTransaction(tx: Record<string, unknown>): Transaction {
+  const txType = detectTxType(tx);
+  const events = (tx.events as Record<string, unknown>[] | undefined) ?? [];
+
+  let amount = 0;
+  for (const event of events) {
+    if (event.event_type === 'stx_asset') {
+      const asset = event.data as Record<string, unknown>;
+      amount = parseInt(String(asset.amount ?? '0'), 10);
+      break;
+    }
+  }
+
+  return {
+    id: String(tx.tx_id ?? ''),
+    type: txType,
+    amount,
+    fee: parseInt(String(tx.fee_rate ?? '0'), 10),
+    status: mapStatus(String(tx.tx_status ?? 'pending')),
+    blockHeight: parseInt(String(tx.block_height ?? '0'), 10),
+    timestamp: parseInt(String(tx.burn_block_time ?? '0'), 10) * 1000,
+    txHash: String(tx.tx_id ?? ''),
+    sender: String(tx.sender_address ?? ''),
+    recipient: extractRecipient(tx),
+  };
+}
+
+function mapStatus(raw: string): 'confirmed' | 'pending' | 'failed' {
+  if (raw === 'success') return 'confirmed';
+  if (raw === 'abort_by_response' || raw === 'abort_by_post_condition') return 'failed';
+  return 'pending';
+}
+
+function detectTxType(tx: Record<string, unknown>): TxType {
+  const fnName = String(
+    (tx.contract_call as Record<string, unknown> | undefined)?.function_name ?? ''
+  );
+  if (fnName === 'deposit') return 'deposit';
+  if (fnName === 'withdraw') return 'withdrawal';
+  if (fnName === 'lock-vault') return 'lock';
+  if (fnName === 'unlock-vault') return 'unlock';
+  if (fnName === 'claim-rewards' || fnName === 'distribute-rewards') return 'reward';
+  return 'deposit';
+}
+
+function extractRecipient(tx: Record<string, unknown>): string | undefined {
+  const events = (tx.events as Record<string, unknown>[] | undefined) ?? [];
+  for (const event of events) {
+    if (event.event_type === 'stx_asset') {
+      const data = event.data as Record<string, unknown>;
+      if (data.recipient) return String(data.recipient);
+    }
+  }
+  return undefined;
+}
+
+export class TxService {
+  private static _instance: TxService | null = null;
+
+  static get instance(): TxService {
+    if (!TxService._instance) {
+      TxService._instance = new TxService();
+    }
+    return TxService._instance;
+  }
+
+  async fetchTxHistory(
+    address: string,
+    limit = 20,
+    offset = 0
+  ): Promise<Transaction[]> {
+    const url = `${API_URL}/extended/v1/address/${address}/transactions?limit=${limit}&offset=${offset}`;
+    const res = await fetch(url, { headers: { Accept: 'application/json' } });
+
+    if (!res.ok) {
+      if (res.status === 404) return [];
+      throw new Error(`Failed to fetch tx history: ${res.status} ${res.statusText}`);
+    }
+
+    const json = await res.json();
+    const results: Record<string, unknown>[] = json.results ?? [];
+    return results.map(mapHiroTxToTransaction);
+  }
+
+  async fetchTxDetails(txHash: string): Promise<Transaction> {
+    const url = `${API_URL}/extended/v1/tx/${txHash}`;
+    const res = await fetch(url, { headers: { Accept: 'application/json' } });
+
+    if (res.status === 404) {
+      throw new Error(`Transaction not found: ${txHash}`);
+    }
+    if (!res.ok) {
+      throw new Error(`Failed to fetch tx details: ${res.status} ${res.statusText}`);
+    }
+
+    const tx = await res.json();
+    return mapHiroTxToTransaction(tx);
+  }
+
+  exportToCSV(transactions: Transaction[]): string {
+    const header = 'Date,Type,Amount STX,Fee STX,Status,TxHash';
+    const rows = transactions.map(tx => {
+      const date = new Date(tx.timestamp).toISOString().split('T')[0];
+      const amountSTX = (tx.amount / 1_000_000).toFixed(6);
+      const feeSTX = (tx.fee / 1_000_000).toFixed(6);
+      return `${date},${tx.type},${amountSTX},${feeSTX},${tx.status},${tx.txHash}`;
+    });
+    return [header, ...rows].join('\n');
+  }
+
+  downloadCSV(csv: string, filename: string): void {
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,0 +1,21 @@
+export type TxType = 'deposit' | 'withdrawal' | 'lock' | 'unlock' | 'reward';
+
+export interface Transaction {
+  id: string;
+  type: TxType;
+  amount: number;
+  fee: number;
+  status: 'confirmed' | 'pending' | 'failed';
+  blockHeight: number;
+  timestamp: number;
+  txHash: string;
+  sender: string;
+  recipient?: string;
+}
+
+export interface TxFilter {
+  type?: TxType;
+  status?: 'confirmed' | 'pending' | 'failed';
+  dateFrom?: number;
+  dateTo?: number;
+}


### PR DESCRIPTION
## Summary
- Add Transaction, TxType, TxFilter types
- Add TxService with Hiro API fetch, CSV export, and download helper
- Add txUtils: hash formatter, type labels/colors, explorer URL, date grouping, and aggregate stats
- Add useTxHistory hook with pagination, client-side filtering, pending tx tracking, and auto-poll on pending
- Add TxHistoryList (grouped by date, skeleton loading), TxHistoryItem (copy button, USD equiv), TxTypeBadge, TxStatusDot, TxFilterBar, TxExportButton
- Integrate full tx history section into vault dashboard; wire addPendingTx to deposit, withdrawal, and lock flows